### PR TITLE
Samplers bugfix

### DIFF
--- a/src/Samplers.jl
+++ b/src/Samplers.jl
@@ -99,13 +99,13 @@ samples the distribution within `s`, `n_draws` times using a random number gener
 function sample(rng::AbstractRNG, s::Sampler, n_draws::Int)
     pd = get_parameter_distribution(s)
     samp = sample(rng, pd, n_draws)
-    constrained_samp = transform_unconstrained_to_constrained(pd,samp)
+    constrained_samp = transform_unconstrained_to_constrained(pd, samp)
     #now create a Samples-type distribution from the samples
     s_names = get_name(pd)
     s_slices = batch(pd) # e.g., [1, 2:3, 4:9]
-    s_samples = [Samples(constrained_samp[slice,:]) for slice in s_slices]    
-    s_constraints = [repeat([no_constraint()],size(slice,1)) for slice in s_slices]
-    
+    s_samples = [Samples(constrained_samp[slice, :]) for slice in s_slices]
+    s_constraints = [repeat([no_constraint()], size(slice, 1)) for slice in s_slices]
+
     return combine_distributions([
         ParameterDistribution(ss, sc, sn) for (ss, sc, sn) in zip(s_samples, s_constraints, s_names)
     ])

--- a/src/Samplers.jl
+++ b/src/Samplers.jl
@@ -99,13 +99,13 @@ samples the distribution within `s`, `n_draws` times using a random number gener
 function sample(rng::AbstractRNG, s::Sampler, n_draws::Int)
     pd = get_parameter_distribution(s)
     samp = sample(rng, pd, n_draws)
+    constrained_samp = transform_unconstrained_to_constrained(pd,samp)
     #now create a Samples-type distribution from the samples
     s_names = get_name(pd)
     s_slices = batch(pd) # e.g., [1, 2:3, 4:9]
-    flat_constraints = get_all_constraints(pd)
-    s_samples = [Samples(samp[slice, :]) for slice in s_slices]
-    s_constraints = [flat_constraints[slice] for slice in s_slices]
-
+    s_samples = [Samples(constrained_samp[slice,:]) for slice in s_slices]    
+    s_constraints = [repeat([no_constraint()],size(slice,1)) for slice in s_slices]
+    
     return combine_distributions([
         ParameterDistribution(ss, sc, sn) for (ss, sc, sn) in zip(s_samples, s_constraints, s_names)
     ])

--- a/test/Samplers/runtests.jl
+++ b/test/Samplers/runtests.jl
@@ -26,7 +26,7 @@ seed = 2022
     @test get_all_constraints(test_pd) == get_all_constraints(pd)
     @test get_name(test_pd) == get_name(pd)
 
-   fsampler = FeatureSampler(pd)
+    fsampler = FeatureSampler(pd)
     @test get_optimizable_parameters(fsampler) == nothing
     @test get_uniform_shift_bounds(fsampler) == [0, 2 * pi]
     unif_pd = ParameterDistribution(
@@ -49,13 +49,13 @@ seed = 2022
 
     # test method: sample
     function sample_to_Sample(pd::ParameterDistribution, samp::AbstractMatrix)
-        constrained_samp = transform_unconstrained_to_constrained(pd,samp)
+        constrained_samp = transform_unconstrained_to_constrained(pd, samp)
         #now create a Samples-type distribution from the samples
         s_names = get_name(pd)
         s_slices = batch(pd) # e.g., [1, 2:3, 4:9]
-        s_samples = [Samples(constrained_samp[slice,:]) for slice in s_slices]    
-        s_constraints = [repeat([no_constraint()],size(slice,1)) for slice in s_slices]
-        
+        s_samples = [Samples(constrained_samp[slice, :]) for slice in s_slices]
+        s_constraints = [repeat([no_constraint()], size(slice, 1)) for slice in s_slices]
+
         return combine_distributions([
             ParameterDistribution(ss, sc, sn) for (ss, sc, sn) in zip(s_samples, s_constraints, s_names)
         ])


### PR DESCRIPTION
## Purpose
To resolve #10 

## Contents
- Samples of the feature distribution are internally stored in constrained space.
- unit tests modified to use a constrained distribution
