### PR TITLE
Streamline Samplers interface

### DIFF
--- a/docs/src/API/Features.md
+++ b/docs/src/API/Features.md
@@ -12,6 +12,7 @@ get_n_features
 get_scalar_function
 get_feature_sampler
 get_feature_sample
+get_feature_parameters
 sample(rf::RandomFeature)
 ```
 # Scalar Functions

--- a/examples/Learn_hyperparameters/1d_to_1d_regression_direct.jl
+++ b/examples/Learn_hyperparameters/1d_to_1d_regression_direct.jl
@@ -20,9 +20,8 @@ end
 using EnsembleKalmanProcesses
 const EKP = EnsembleKalmanProcesses
 
-using EnsembleKalmanProcesses.ParameterDistributions
-using EnsembleKalmanProcesses.DataContainers
-
+using RandomFeatures.ParameterDistributions
+using RandomFeatures.DataContainers
 using RandomFeatures.Samplers
 using RandomFeatures.Features
 using RandomFeatures.Methods
@@ -36,7 +35,6 @@ rng = StableRNG(seed)
 function RFM_from_hyperparameters(
     rng::AbstractRNG,
     l::Real,
-    s::Real,
     regularizer::Real,
     n_features::Int,
     batch_sizes::Dict,
@@ -50,11 +48,11 @@ function RFM_from_hyperparameters(
     # Learn hyperparameters for different feature types
 
     if feature_type == "fourier"
-        sf = ScalarFourierFeature(n_features, feature_sampler, hyper_fixed = Dict("sigma" => s))
+        sf = ScalarFourierFeature(n_features, feature_sampler)
     elseif feature_type == "neuron"
-        sf = ScalarNeuronFeature(n_features, feature_sampler, hyper_fixed = Dict("sigma" => s))
+        sf = ScalarNeuronFeature(n_features, feature_sampler)
     elseif feature_type == "sigmoid"
-        sf = ScalarFeature(n_features, feature_sampler, Sigmoid(), hyper_fixed = Dict("sigma" => s))
+        sf = ScalarFeature(n_features, feature_sampler, Sigmoid())
     end
     return RandomFeatureMethod(sf, regularization = regularizer)
 end
@@ -63,7 +61,6 @@ end
 function calculate_mean_and_coeffs(
     rng::AbstractRNG,
     l::Real,
-    s::Real,
     noise_sd::Real,
     n_features::Int,
     batch_sizes::Dict,
@@ -82,7 +79,7 @@ function calculate_mean_and_coeffs(
     otest = reshape(get_outputs(io_pairs)[1, (n_train + 1):end], 1, :)
 
     # build and fit the RF
-    rfm = RFM_from_hyperparameters(rng, l, s, regularizer, n_features, batch_sizes, feature_type)
+    rfm = RFM_from_hyperparameters(rng, l, regularizer, n_features, batch_sizes, feature_type)
     fitted_features = fit(rfm, io_train_cost)
 
     test_batch_size = get_batch_size(rfm, "test")
@@ -98,7 +95,6 @@ end
 function estimate_mean_and_coeffnorm_covariance(
     rng::AbstractRNG,
     l::Real,
-    s::Real,
     noise_sd::Real,
     n_features::Int,
     batch_sizes::Dict,
@@ -113,7 +109,7 @@ function estimate_mean_and_coeffnorm_covariance(
     coeffl2norm = zeros(1, n_samples)
     for i in 1:n_samples
         for j in 1:repeats
-            m, c = calculate_mean_and_coeffs(rng, l, s, noise_sd, n_features, batch_sizes, io_pairs, feature_type)
+            m, c = calculate_mean_and_coeffs(rng, l, noise_sd, n_features, batch_sizes, io_pairs, feature_type)
             means[:, i] += m' / repeats
             coeffl2norm[1, i] += sqrt(sum(c .^ 2)) / repeats
         end
@@ -127,7 +123,6 @@ end
 function calculate_ensemble_mean_and_coeffnorm(
     rng::AbstractRNG,
     lvec::AbstractVector,
-    svec::AbstractVector,
     noise_sd::Real,
     n_features::Int,
     batch_sizes::Dict,
@@ -141,9 +136,9 @@ function calculate_ensemble_mean_and_coeffnorm(
 
     means = zeros(n_test, N_ens)
     coeffl2norm = zeros(1, N_ens)
-    for (i, l, s) in zip(collect(1:N_ens), lvec, svec)
+    for (i, l) in zip(collect(1:N_ens), lvec)
         for j in collect(1:repeats)
-            m, c = calculate_mean_and_coeffs(rng, l, s, noise_sd, n_features, batch_sizes, io_pairs, feature_type)
+            m, c = calculate_mean_and_coeffs(rng, l, noise_sd, n_features, batch_sizes, io_pairs, feature_type)
             means[:, i] += m' / repeats
             coeffl2norm[1, i] += sqrt(sum(c .^ 2)) / repeats
         end
@@ -183,11 +178,6 @@ ytest = ftest(get_data(xtest))
 σ_l = 10.0
 prior_lengthscale = constrained_gaussian("lengthscale", μ_l, σ_l, 0.0, Inf)
 
-μ_s = 1.0
-#σ_s = 5.0
-#prior_scaling = constrained_gaussian("scaling", μ_l, σ_l, 0.0, Inf)
-#priors = combine_distributions([prior_lengthscale, prior_scaling])
-
 priors = prior_lengthscale
 
 # estimate the noise from running many RFM sample costs at the mean values
@@ -206,7 +196,6 @@ for (idx, type) in enumerate(feature_types)
     internal_Γ = estimate_mean_and_coeffnorm_covariance(
         rng,
         μ_l, # take mean values
-        μ_s, # take mean values
         noise_sd,
         n_features,
         batch_sizes,
@@ -238,7 +227,6 @@ for (idx, type) in enumerate(feature_types)
         g_ens = calculate_ensemble_mean_and_coeffnorm(
             rng,
             lvec,
-            repeat([μ_s], length(lvec)),#svec,
             noise_sd,
             n_features,
             batch_sizes,
@@ -289,11 +277,11 @@ for (idx, sd, feature_type) in zip(collect(1:length(σ_c)), σ_c, feature_types)
     feature_sampler = FeatureSampler(pd, rng = copy(rng))
 
     if feature_type == "fourier"
-        sf = ScalarFourierFeature(n_features_test, feature_sampler, hyper_fixed = Dict("sigma" => 1.0))
+        sf = ScalarFourierFeature(n_features_test, feature_sampler)
     elseif feature_type == "neuron"
-        sf = ScalarNeuronFeature(n_features_test, feature_sampler, hyper_fixed = Dict("sigma" => 1.0))
+        sf = ScalarNeuronFeature(n_features_test, feature_sampler)
     elseif feature_type == "sigmoid"
-        sf = ScalarFeature(n_features_test, feature_sampler, Sigmoid(), hyper_fixed = Dict("sigma" => 1.0))
+        sf = ScalarFeature(n_features_test, feature_sampler, Sigmoid())
     end
 
     push!(rfms, RandomFeatureMethod(sf, batch_sizes = batch_sizes, regularization = regularizer))

--- a/examples/Learn_hyperparameters/1d_to_1d_regression_direct_withcov.jl
+++ b/examples/Learn_hyperparameters/1d_to_1d_regression_direct_withcov.jl
@@ -19,9 +19,8 @@ end
 using EnsembleKalmanProcesses
 const EKP = EnsembleKalmanProcesses
 
-using EnsembleKalmanProcesses.ParameterDistributions
-using EnsembleKalmanProcesses.DataContainers
-
+using RandomFeatures.ParameterDistributions
+using RandomFeatures.DataContainers
 using RandomFeatures.Samplers
 using RandomFeatures.Features
 using RandomFeatures.Methods
@@ -35,7 +34,6 @@ rng = StableRNG(seed)
 function RFM_from_hyperparameters(
     rng::AbstractRNG,
     l::Real,
-    s::Real,
     regularizer::Real,
     n_features::Int,
     batch_sizes::Dict,
@@ -49,11 +47,11 @@ function RFM_from_hyperparameters(
     # Learn hyperparameters for different feature types
 
     if feature_type == "fourier"
-        sf = ScalarFourierFeature(n_features, feature_sampler, hyper_fixed = Dict("sigma" => s))
+        sf = ScalarFourierFeature(n_features, feature_sampler)
     elseif feature_type == "neuron"
-        sf = ScalarNeuronFeature(n_features, feature_sampler, hyper_fixed = Dict("sigma" => s))
+        sf = ScalarNeuronFeature(n_features, feature_sampler)
     elseif feature_type == "sigmoid"
-        sf = ScalarFeature(n_features, feature_sampler, Sigmoid(), hyper_fixed = Dict("sigma" => s))
+        sf = ScalarFeature(n_features, feature_sampler, Sigmoid())
     end
     return RandomFeatureMethod(sf, regularization = regularizer)
 end
@@ -62,7 +60,6 @@ end
 function calculate_mean_cov_and_coeffs(
     rng::AbstractRNG,
     l::Real,
-    s::Real,
     noise_sd::Real,
     n_features::Int,
     batch_sizes::Dict,
@@ -81,7 +78,7 @@ function calculate_mean_cov_and_coeffs(
     otest = reshape(get_outputs(io_pairs)[1, (n_train + 1):end], 1, :)
 
     # build and fit the RF
-    rfm = RFM_from_hyperparameters(rng, l, s, regularizer, n_features, batch_sizes, feature_type)
+    rfm = RFM_from_hyperparameters(rng, l, regularizer, n_features, batch_sizes, feature_type)
     fitted_features = fit(rfm, io_train_cost)
 
     test_batch_size = get_batch_size(rfm, "test")
@@ -97,7 +94,6 @@ end
 function estimate_mean_cov_and_coeffnorm_covariance(
     rng::AbstractRNG,
     l::Real,
-    s::Real,
     noise_sd::Real,
     n_features::Int,
     batch_sizes::Dict,
@@ -113,8 +109,7 @@ function estimate_mean_cov_and_coeffnorm_covariance(
     coeffl2norm = zeros(1, n_samples)
     for i in 1:n_samples
         for j in 1:repeats
-            m, v, c =
-                calculate_mean_cov_and_coeffs(rng, l, s, noise_sd, n_features, batch_sizes, io_pairs, feature_type)
+            m, v, c = calculate_mean_cov_and_coeffs(rng, l, noise_sd, n_features, batch_sizes, io_pairs, feature_type)
             means[:, i] += m' / repeats
             covs[:, i] += v' / repeats
             coeffl2norm[1, i] += sqrt(sum(c .^ 2)) / repeats
@@ -130,7 +125,6 @@ end
 function calculate_ensemble_mean_cov_and_coeffnorm(
     rng::AbstractRNG,
     lvec::AbstractVector,
-    svec::AbstractVector,
     noise_sd::Real,
     n_features::Int,
     batch_sizes::Dict,
@@ -145,10 +139,9 @@ function calculate_ensemble_mean_cov_and_coeffnorm(
     means = zeros(n_test, N_ens)
     covs = zeros(n_test, N_ens)
     coeffl2norm = zeros(1, N_ens)
-    for (i, l, s) in zip(collect(1:N_ens), lvec, svec)
+    for (i, l) in zip(collect(1:N_ens), lvec)
         for j in collect(1:repeats)
-            m, v, c =
-                calculate_mean_cov_and_coeffs(rng, l, s, noise_sd, n_features, batch_sizes, io_pairs, feature_type)
+            m, v, c = calculate_mean_cov_and_coeffs(rng, l, noise_sd, n_features, batch_sizes, io_pairs, feature_type)
             means[:, i] += m' / repeats
             covs[:, i] += v' / repeats
             coeffl2norm[1, i] += sqrt(sum(c .^ 2)) / repeats
@@ -189,12 +182,6 @@ ytest = ftest(get_data(xtest))
 μ_l = 10.0
 σ_l = 10.0
 prior_lengthscale = constrained_gaussian("lengthscale", μ_l, σ_l, 0.0, Inf)
-
-μ_s = 1.0
-#σ_s = 5.0
-#prior_scaling = constrained_gaussian("scaling", μ_l, σ_l, 0.0, Inf)
-#priors = combine_distributions([prior_lengthscale, prior_scaling])
-
 priors = prior_lengthscale
 
 # estimate the noise from running many RFM sample costs at the mean values
@@ -213,7 +200,6 @@ for (idx, type) in enumerate(feature_types)
     internal_Γ, approx_σ = estimate_mean_cov_and_coeffnorm_covariance(
         rng,
         μ_l, # take mean values
-        μ_s, # take mean values
         noise_sd,
         n_features,
         batch_sizes,
@@ -245,7 +231,6 @@ for (idx, type) in enumerate(feature_types)
         g_ens, approx_σ_ens = calculate_ensemble_mean_cov_and_coeffnorm(
             rng,
             lvec,
-            repeat([μ_s], length(lvec)),#svec,
             noise_sd,
             n_features,
             batch_sizes,
@@ -303,11 +288,11 @@ for (idx, sd, feature_type) in zip(collect(1:length(σ_c)), σ_c, feature_types)
     feature_sampler = FeatureSampler(pd, rng = copy(rng))
 
     if feature_type == "fourier"
-        sf = ScalarFourierFeature(n_features_test, feature_sampler, hyper_fixed = Dict("sigma" => 1.0))
+        sf = ScalarFourierFeature(n_features_test, feature_sampler)
     elseif feature_type == "neuron"
-        sf = ScalarNeuronFeature(n_features_test, feature_sampler, hyper_fixed = Dict("sigma" => 1.0))
+        sf = ScalarNeuronFeature(n_features_test, feature_sampler)
     elseif feature_type == "sigmoid"
-        sf = ScalarFeature(n_features_test, feature_sampler, Sigmoid(), hyper_fixed = Dict("sigma" => 1.0))
+        sf = ScalarFeature(n_features_test, feature_sampler, Sigmoid())
     end
 
     push!(rfms, RandomFeatureMethod(sf, batch_sizes = batch_sizes, regularization = regularizer))

--- a/examples/Learn_hyperparameters/Project.toml
+++ b/examples/Learn_hyperparameters/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 EnsembleKalmanProcesses = "aa8a2aa5-91d8-4396-bcef-d4f2ec43552d"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/examples/Learn_hyperparameters/nd_to_1d_regression_direct_matchingcov.jl
+++ b/examples/Learn_hyperparameters/nd_to_1d_regression_direct_matchingcov.jl
@@ -18,11 +18,10 @@ if PLOT_FLAG
 end
 using EnsembleKalmanProcesses
 const EKP = EnsembleKalmanProcesses
-
-using EnsembleKalmanProcesses.ParameterDistributions
-using EnsembleKalmanProcesses.DataContainers
 using EnsembleKalmanProcesses.Localizers
 
+using RandomFeatures.ParameterDistributions
+using RandomFeatures.DataContainers
 using RandomFeatures.Samplers
 using RandomFeatures.Features
 using RandomFeatures.Methods
@@ -36,7 +35,6 @@ rng = StableRNG(seed)
 function RFM_from_hyperparameters(
     rng::AbstractRNG,
     l::Union{Real, AbstractVecOrMat},
-    s::Real,
     regularizer::Real,
     n_features::Int,
     batch_sizes::Dict,
@@ -67,7 +65,7 @@ function RFM_from_hyperparameters(
     feature_sampler = FeatureSampler(pd, rng = rng)
     # Learn hyperparameters for different feature types
 
-    sf = ScalarFourierFeature(n_features, feature_sampler, hyper_fixed = Dict("sigma" => s))
+    sf = ScalarFourierFeature(n_features, feature_sampler)
     return RandomFeatureMethod(sf, regularization = regularizer)
 end
 
@@ -75,7 +73,6 @@ end
 function calculate_mean_cov_and_coeffs(
     rng::AbstractRNG,
     l::Union{Real, AbstractVecOrMat},
-    s::Real,
     noise_sd::Real,
     n_features::Int,
     batch_sizes::Dict,
@@ -95,7 +92,7 @@ function calculate_mean_cov_and_coeffs(
     input_dim = size(itrain, 1)
 
     # build and fit the RF
-    rfm = RFM_from_hyperparameters(rng, l, s, regularizer, n_features, batch_sizes, input_dim)
+    rfm = RFM_from_hyperparameters(rng, l, regularizer, n_features, batch_sizes, input_dim)
     fitted_features = fit(rfm, io_train_cost, decomposition_type = "svd")
 
     test_batch_size = get_batch_size(rfm, "test")
@@ -112,7 +109,6 @@ end
 function estimate_mean_cov_and_coeffnorm_covariance(
     rng::AbstractRNG,
     l::Union{Real, AbstractVecOrMat},
-    s::Real,
     noise_sd::Real,
     n_features::Int,
     batch_sizes::Dict,
@@ -127,7 +123,7 @@ function estimate_mean_cov_and_coeffnorm_covariance(
     coeffl2norm = zeros(1, n_samples)
     for i in 1:n_samples
         for j in 1:repeats
-            m, v, c = calculate_mean_cov_and_coeffs(rng, l, s, noise_sd, n_features, batch_sizes, io_pairs)
+            m, v, c = calculate_mean_cov_and_coeffs(rng, l, noise_sd, n_features, batch_sizes, io_pairs)
             means[:, i] += m' / repeats
             covs[:, i] += v' / repeats
             coeffl2norm[1, i] += sqrt(sum(c .^ 2)) / repeats
@@ -144,7 +140,6 @@ end
 function calculate_ensemble_mean_cov_and_coeffnorm(
     rng::AbstractRNG,
     lvecormat::AbstractVecOrMat,
-    s::Real,
     noise_sd::Real,
     n_features::Int,
     batch_sizes::Dict,
@@ -166,7 +161,7 @@ function calculate_ensemble_mean_cov_and_coeffnorm(
     for i in collect(1:N_ens)
         for j in collect(1:repeats)
             l = lmat[:, i]
-            m, v, c = calculate_mean_cov_and_coeffs(rng, l, s, noise_sd, n_features, batch_sizes, io_pairs)
+            m, v, c = calculate_mean_cov_and_coeffs(rng, l, noise_sd, n_features, batch_sizes, io_pairs)
             means[:, i] += m' / repeats
             covs[:, i] += v' / repeats
             coeffl2norm[1, i] += sqrt(sum(c .^ 2)) / repeats
@@ -206,8 +201,6 @@ for input_dim in input_dim_list
     prior_lengthscale = constrained_gaussian("lengthscale", μ_l, σ_l, 0.0, Inf, repeats = input_dim)
     priors = prior_lengthscale
 
-    μ_s = 1.0
-
     # estimate the noise from running many RFM sample costs at the mean values
     batch_sizes = Dict("train" => 600, "test" => 600, "feature" => 600)
     n_train = Int(floor(0.8 * n_data))
@@ -230,7 +223,6 @@ for input_dim in input_dim_list
         internal_Γ, approx_σ2 = estimate_mean_cov_and_coeffnorm_covariance(
             rng,
             μ_l, # take mean values
-            μ_s, # take mean values
             noise_sd,
             n_features,
             batch_sizes,
@@ -282,7 +274,6 @@ for input_dim in input_dim_list
         g_ens, _ = calculate_ensemble_mean_cov_and_coeffnorm(
             rng,
             lvec,
-            μ_s,
             noise_sd,
             n_features,
             batch_sizes,
@@ -297,7 +288,6 @@ for input_dim in input_dim_list
             internal_Γ_new, approx_σ2_new = estimate_mean_cov_and_coeffnorm_covariance(
                 rng,
                 mean(constrained_u, dims = 2)[:, 1], # take mean values
-                μ_s, # take mean values
                 noise_sd,
                 n_features,
                 batch_sizes,
@@ -373,8 +363,7 @@ for input_dim in input_dim_list
         ),
     )
     feature_sampler = FeatureSampler(pd, rng = copy(rng))
-    sigma_fixed = Dict("sigma" => 1.0)
-    sff = ScalarFourierFeature(n_features_test, feature_sampler, hyper_fixed = sigma_fixed)
+    sff = ScalarFourierFeature(n_features_test, feature_sampler)
 
     #second case with batching
 

--- a/src/Methods.jl
+++ b/src/Methods.jl
@@ -321,23 +321,10 @@ function predictive_cov(rfm::RandomFeatureMethod, fit::Fit, new_inputs::DataCont
     return cov_outputs, coeff_outputs
 end
 
-
-function posterior_cov(rfm::RandomFeatureMethod, u_input, v_input)
-
-end
-
-function get_optimizable_hyperparameters(rfm::RandomFeatureMethod)
-
-end
-
-function set_optimized_hyperparameters(rfm::RandomFeatureMethod, optimized_hyperparameters)
-
-end
-
-function evaluate_hyperparameter_cost(rfm::RandomFeatureMethod, input_data, output_data)
-
-end
-
+# TODO
+# function posterior_cov(rfm::RandomFeatureMethod, u_input, v_input)
+# 
+# end
 
 
 end # module

--- a/src/RandomFeatures.jl
+++ b/src/RandomFeatures.jl
@@ -1,6 +1,18 @@
+"""
+# Imported modules:
+$(IMPORTS)
+
+# Exports:
+$(EXPORTS)
+"""
 module RandomFeatures
 
 using Statistics, LinearAlgebra, DocStringExtensions
+
+# importing parameter distirbutions
+import EnsembleKalmanProcesses: ParameterDistributions, DataContainers
+
+export ParameterDistributions, DataContainers
 
 #auxiliary modules
 include("Utilities.jl") # some additional tools

--- a/src/Samplers.jl
+++ b/src/Samplers.jl
@@ -4,14 +4,7 @@ import StatsBase: sample
 
 using Random, Distributions, DocStringExtensions, EnsembleKalmanProcesses.ParameterDistributions
 
-export Sampler,
-    FeatureSampler,
-    HyperSampler,
-    get_parameter_distribution,
-    get_optimizable_parameters,
-    get_uniform_shift_bounds,
-    get_rng,
-    sample
+export Sampler, FeatureSampler, get_parameter_distribution, get_uniform_shift_bounds, get_rng, sample
 
 """
 $(TYPEDEF)
@@ -23,7 +16,6 @@ $(TYPEDFIELDS)
 struct Sampler
     "A probability distribution, possibly with constraints"
     parameter_distribution::ParameterDistribution
-    optimizable_parameters::Union{AbstractVector, Nothing}
     "Either `nothing` , or `[lower bound, upper bound]`, which defines a uniform distribution used as a random shift"
     uniform_shift_bounds::Union{AbstractVector, Nothing}
     "A random number generator state"
@@ -37,7 +29,6 @@ basic constructor for a `Sampler`
 """
 function FeatureSampler(
     parameter_distribution::ParameterDistribution;
-    optimizable_parameters::Union{AbstractVector, Nothing} = nothing,
     uniform_shift_bounds::Union{AbstractVector, Nothing} = [0, 2 * pi],
     rng::AbstractRNG = Random.GLOBAL_RNG,
 )
@@ -59,13 +50,7 @@ function FeatureSampler(
         uniform_shift_bounds = nothing
     end
 
-    return Sampler(pd, optimizable_parameters, uniform_shift_bounds, rng)
-
-end
-
-
-function HyperSampler(parameter_distribution::ParameterDistribution; rng::AbstractRNG = Random.GLOBAL_RNG)
-    return Sampler(parameter_distribution, nothing, nothing, rng)
+    return Sampler(pd, uniform_shift_bounds, rng)
 
 end
 
@@ -75,7 +60,6 @@ $(TYPEDSIGNATURES)
 gets the `parameter_distribution` field 
 """
 get_parameter_distribution(s::Sampler) = s.parameter_distribution
-get_optimizable_parameters(s::Sampler) = s.optimizable_parameters
 
 """
 $(TYPEDSIGNATURES)

--- a/test/Methods/runtests.jl
+++ b/test/Methods/runtests.jl
@@ -5,13 +5,13 @@ using StatsBase
 using LinearAlgebra
 using Random
 
-using EnsembleKalmanProcesses.DataContainers
-using EnsembleKalmanProcesses.ParameterDistributions
 
 using RandomFeatures.Utilities
 using RandomFeatures.Samplers
 using RandomFeatures.Features
 using RandomFeatures.Methods
+using RandomFeatures.DataContainers
+using RandomFeatures.ParameterDistributions
 
 
 seed = 2023
@@ -30,7 +30,7 @@ seed = 2023
         n_features = 100
         sigma_fixed = Dict("sigma" => 10.0)
 
-        sff = ScalarFourierFeature(n_features, feature_sampler, hyper_fixed = sigma_fixed)
+        sff = ScalarFourierFeature(n_features, feature_sampler, feature_parameters = sigma_fixed)
 
         # configure the method, and fit 
         batch_sizes_err = Dict("train" => 100, "test" => 100, "NOT_FEATURES" => 100)
@@ -96,24 +96,23 @@ seed = 2023
             # NB we optimize hyperparameter values (σ_c,"sigma") in examples/Learn_hyperparameters/1d_to_1d_regression.jl
             # Such values may change with different ftest and different noise_sd
 
-            sigma_fixed = Dict("sigma" => 1.0)
             n_features = 400
 
             μ_c = 0.0
             pd = constrained_gaussian("xi", μ_c, σ_c, -Inf, Inf)
             feature_sampler = FeatureSampler(pd, rng = copy(rng))
 
-            sff = ScalarFourierFeature(n_features, feature_sampler, hyper_fixed = sigma_fixed)
+            sff = ScalarFourierFeature(n_features, feature_sampler)
 
-            sff = ScalarFourierFeature(n_features, feature_sampler, hyper_fixed = sigma_fixed)
+            sff = ScalarFourierFeature(n_features, feature_sampler)
 
             pd_snf = constrained_gaussian("xi", μ_c, σ_c_snf, -Inf, Inf)
             feature_sampler_snf = FeatureSampler(pd_snf, rng = copy(rng))
-            snf = ScalarNeuronFeature(n_features, feature_sampler_snf, hyper_fixed = sigma_fixed)
+            snf = ScalarNeuronFeature(n_features, feature_sampler_snf)
 
             pd_ssf = constrained_gaussian("xi", μ_c, σ_c_ssf, -Inf, Inf)
             feature_sampler_ssf = FeatureSampler(pd_ssf, rng = copy(rng))
-            ssf = ScalarFeature(n_features, feature_sampler_ssf, Sigmoid(), hyper_fixed = sigma_fixed)
+            ssf = ScalarFeature(n_features, feature_sampler_ssf, Sigmoid())
             #first case without batches
             lambda = noise_sd^2
             rfm = RandomFeatureMethod(sff, regularization = lambda)
@@ -274,8 +273,7 @@ seed = 2023
             ),
         )
         feature_sampler = FeatureSampler(pd, rng = copy(rng))
-        sigma_fixed = Dict("sigma" => 1.0)
-        sff = ScalarFourierFeature(n_features, feature_sampler, hyper_fixed = sigma_fixed)
+        sff = ScalarFourierFeature(n_features, feature_sampler)
 
         #second case with batching
         batch_sizes = Dict("train" => 500, "test" => 500, "feature" => 500)

--- a/test/Samplers/runtests.jl
+++ b/test/Samplers/runtests.jl
@@ -4,8 +4,8 @@ using StableRNGs
 using StatsBase
 using LinearAlgebra
 using Random
-using EnsembleKalmanProcesses.ParameterDistributions
 
+using RandomFeatures.ParameterDistributions
 using RandomFeatures.Samplers
 
 seed = 2022
@@ -18,16 +18,8 @@ seed = 2022
     σ_c = 1.0
 
     pd = constrained_gaussian("xi", μ_c, σ_c, -Inf, 0.0)
-    hsampler = HyperSampler(pd)
-    @test get_optimizable_parameters(hsampler) == nothing
-    @test get_uniform_shift_bounds(hsampler) == nothing
-    test_pd = get_parameter_distribution(hsampler)
-    @test get_distribution(test_pd) == get_distribution(pd)
-    @test get_all_constraints(test_pd) == get_all_constraints(pd)
-    @test get_name(test_pd) == get_name(pd)
 
     fsampler = FeatureSampler(pd)
-    @test get_optimizable_parameters(fsampler) == nothing
     @test get_uniform_shift_bounds(fsampler) == [0, 2 * pi]
     unif_pd = ParameterDistribution(
         Dict("distribution" => Parameterized(Uniform(0, 2 * π)), "constraint" => no_constraint(), "name" => "uniform"),
@@ -41,11 +33,8 @@ seed = 2022
 
     # and other option for settings
     usb = nothing
-    oh = [:μ]
-    sampler2 = FeatureSampler(pd, optimizable_parameters = oh, uniform_shift_bounds = usb)
-
+    sampler2 = FeatureSampler(pd, uniform_shift_bounds = usb)
     @test get_uniform_shift_bounds(sampler2) == usb
-    @test get_optimizable_parameters(sampler2) == oh
 
     # test method: sample
     function sample_to_Sample(pd::ParameterDistribution, samp::AbstractMatrix)


### PR DESCRIPTION
## Purpose
Removes aspects of the over-engineered interface
addresses some points in #1 

# content 
- removes `hyper_sampler`  and get methods relating to internal optimization
- changes `hyper_fixed` to `feature_parameters`
- changes examples and docs API to reflect this
