### PR TITLE
Multi-output random features

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -15,7 +15,7 @@ jobs:
        matrix:
         version:
           - '1.6' # Long-Term Support release
-          - '1.7.3' # Latest 1.x release of julia
+          - '1.8' # Latest 1.x release of julia
         os:
           - ubuntu-latest
           - windows-latest

--- a/Project.toml
+++ b/Project.toml
@@ -12,16 +12,17 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+Tullio = "bc48ee85-29a4-5162-ae0b-a64e1601d4bc"
 
 [compat]
+ColorSchemes = "3.19"
 Distributions = "0.25"
 DocStringExtensions = "0.9"
 EnsembleKalmanProcesses = "0.10, 0.11, 0.12, 0.13"
-SpecialFunctions = "2"
-StatsBase = "0.33"
 Plots = "1.34"
-ColorSchemes = "3.19"
+SpecialFunctions = "2"
 StableRNGs = "1.0"
+StatsBase = "0.33"
 julia = "1.6"
 
 [extras]

--- a/docs/src/API/Features.md
+++ b/docs/src/API/Features.md
@@ -5,16 +5,32 @@ CurrentModule = RandomFeatures.Features
 ```
 
 ```@docs
-ScalarFeature
-ScalarFourierFeature
-ScalarNeuronFeature
-get_n_features
 get_scalar_function
 get_feature_sampler
 get_feature_sample
+get_n_features
 get_feature_parameters
+get_output_dim
 sample(rf::RandomFeature)
 ```
+
+# [Scalar Features](@id scalar-features)
+
+```@docs
+ScalarFeature
+ScalarFourierFeature
+ScalarNeuronFeature
+build_features(rf::ScalarFeature,inputs::AbstractMatrix,atch_feature_idx::AbstractVector{Int})
+```
+# [Vector Features](@id vector-features)
+
+```@docs
+VectorFeature
+VectorFourierFeature
+VectorNeuronFeature
+build_features(rf::VectorFeature,inputs::AbstractMatrix,atch_feature_idx::AbstractVector{Int})
+```
+
 # [Scalar Functions](@id scalar-functions)
 
 ```@docs

--- a/docs/src/API/Samplers.md
+++ b/docs/src/API/Samplers.md
@@ -8,7 +8,6 @@ CurrentModule = RandomFeatures.Samplers
 Sampler
 FeatureSampler
 get_parameter_distribution
-get_uniform_shift_bounds
 get_rng
 sample(rng::AbstractRNG, s::Sampler, n_draws::Int)
 ```

--- a/examples/Learn_hyperparameters/1d_to_1d_regression_direct.jl
+++ b/examples/Learn_hyperparameters/1d_to_1d_regression_direct.jl
@@ -54,7 +54,7 @@ function RFM_from_hyperparameters(
     elseif feature_type == "sigmoid"
         sf = ScalarFeature(n_features, feature_sampler, Sigmoid())
     end
-    return RandomFeatureMethod(sf, regularization = regularizer)
+    return RandomFeatureMethod(sf, batch_sizes = batch_sizes, regularization = regularizer)
 end
 
 

--- a/examples/Learn_hyperparameters/1d_to_1d_regression_direct_withcov.jl
+++ b/examples/Learn_hyperparameters/1d_to_1d_regression_direct_withcov.jl
@@ -53,7 +53,7 @@ function RFM_from_hyperparameters(
     elseif feature_type == "sigmoid"
         sf = ScalarFeature(n_features, feature_sampler, Sigmoid())
     end
-    return RandomFeatureMethod(sf, regularization = regularizer)
+    return RandomFeatureMethod(sf, batch_sizes = batch_sizes, regularization = regularizer)
 end
 
 

--- a/examples/Learn_hyperparameters/nd_to_1d_regression_direct.jl
+++ b/examples/Learn_hyperparameters/nd_to_1d_regression_direct.jl
@@ -66,7 +66,7 @@ function RFM_from_hyperparameters(
     # Learn hyperparameters for different feature types
 
     sf = ScalarFourierFeature(n_features, feature_sampler)
-    return RandomFeatureMethod(sf, regularization = regularizer)
+    return RandomFeatureMethod(sf, batch_sizes = batch_sizes, regularization = regularizer)
 end
 
 

--- a/examples/Learn_hyperparameters/nd_to_1d_regression_direct_matchingcov.jl
+++ b/examples/Learn_hyperparameters/nd_to_1d_regression_direct_matchingcov.jl
@@ -66,7 +66,7 @@ function RFM_from_hyperparameters(
     # Learn hyperparameters for different feature types
 
     sf = ScalarFourierFeature(n_features, feature_sampler)
-    return RandomFeatureMethod(sf, regularization = regularizer)
+    return RandomFeatureMethod(sf, batch_sizes = batch_sizes, regularization = regularizer)
 end
 
 
@@ -124,8 +124,8 @@ function estimate_mean_cov_and_coeffnorm_covariance(
     for i in 1:n_samples
         for j in 1:repeats
             m, v, c = calculate_mean_cov_and_coeffs(rng, l, noise_sd, n_features, batch_sizes, io_pairs)
-            means[:, i] += m' / repeats
-            covs[:, i] += v' / repeats
+            means[:, i] += m[1, :] / repeats
+            covs[:, i] += v[1, 1, :] / repeats
             coeffl2norm[1, i] += sqrt(sum(c .^ 2)) / repeats
         end
     end
@@ -162,8 +162,8 @@ function calculate_ensemble_mean_cov_and_coeffnorm(
         for j in collect(1:repeats)
             l = lmat[:, i]
             m, v, c = calculate_mean_cov_and_coeffs(rng, l, noise_sd, n_features, batch_sizes, io_pairs)
-            means[:, i] += m' / repeats
-            covs[:, i] += v' / repeats
+            means[:, i] += m[1, :] / repeats
+            covs[:, i] += v[1, 1, :] / repeats
             coeffl2norm[1, i] += sqrt(sum(c .^ 2)) / repeats
         end
     end
@@ -175,7 +175,7 @@ end
 ## Begin Script, define problem setting
 println("Begin script")
 date_of_run = Date(2022, 9, 22)
-input_dim_list = [6]
+input_dim_list = [8]
 
 for input_dim in input_dim_list
     println("Number of input dimensions: ", input_dim)
@@ -397,11 +397,10 @@ for input_dim in input_dim_list
                 legend = :topleft,
                 label = "Target",
             )
-            println(mean(2 * sqrt.(pred_cov_slice)))
             plot!(
                 xrange,
                 pred_mean_slice',
-                ribbon = [2 * sqrt.(pred_cov_slice); 2 * sqrt.(pred_cov_slice)]',
+                ribbon = [2 * sqrt.(pred_cov_slice[1, 1, :]); 2 * sqrt.(pred_cov_slice[1, 1, :])]',
                 label = "Fourier",
                 color = "blue",
             )

--- a/examples/Learn_hyperparameters/nd_to_md_regression_direct_withcov.jl
+++ b/examples/Learn_hyperparameters/nd_to_md_regression_direct_withcov.jl
@@ -1,0 +1,475 @@
+# Example to learn hyperparameters of simple 1d-1d regression example.
+# This example matches test/Methods/runtests.jl testset: "Fit and predict: 1D -> 1D"
+# The (approximate) optimal values here are used in those tests.
+
+
+using StableRNGs
+using Distributions
+using JLD2
+using StatsBase
+using LinearAlgebra
+using Random
+using Dates
+
+PLOT_FLAG = true
+println("plot flag:", PLOT_FLAG)
+if PLOT_FLAG
+    using Plots
+end
+using EnsembleKalmanProcesses
+const EKP = EnsembleKalmanProcesses
+using EnsembleKalmanProcesses.Localizers
+
+using RandomFeatures.ParameterDistributions
+using RandomFeatures.DataContainers
+using RandomFeatures.Samplers
+using RandomFeatures.Features
+using RandomFeatures.Methods
+using RandomFeatures.Utilities
+
+seed = 2024
+ekp_seed = 99999
+rng = StableRNG(seed)
+
+## Functions of use
+function RFM_from_hyperparameters(
+    rng::AbstractRNG,
+    l::Union{Real, AbstractVecOrMat},
+    regularizer::Real,
+    n_features::Int,
+    batch_sizes::Dict,
+    input_dim::Int,
+    output_dim::Int,
+)
+
+    # l = [input_dim params + output_dim params]
+    μ_c = 0.0
+
+    if isa(l, Real)
+        σ_c = fill(l, input_dim)
+    elseif isa(l, AbstractVector)
+        if length(l) == 1
+            σ_c = fill(l[1], input_dim)
+        else
+            σ_c = l[1:input_dim]
+        end
+    end
+    if isa(l, Real)
+        σ_o = fill(l, output_dim)
+    elseif isa(l, AbstractVector)
+        if length(l) == 1
+            σ_o = fill(l[1], output_dim)
+        else
+            σ_o = l[(input_dim + 1):end]
+        end
+    end
+
+    M = zeros(input_dim, output_dim) # n x p mean
+    U = Diagonal(σ_c) # input covariance
+    V = Diagonal(σ_o) # output covariance
+    dist = MatrixNormal(M, U, V)
+    pd = ParameterDistribution(
+        Dict(
+            "distribution" => Parameterized(dist),
+            "constraint" => repeat([no_constraint()], input_dim * output_dim),
+            "name" => "xi",
+        ),
+    )
+    feature_sampler = FeatureSampler(pd, output_dim, rng = copy(rng))
+    vff = VectorFourierFeature(n_features, output_dim, feature_sampler)
+
+    return RandomFeatureMethod(vff, batch_sizes = batch_sizes, regularization = lambda)
+end
+
+
+function calculate_mean_cov_and_coeffs(
+    rng::AbstractRNG,
+    l::Union{Real, AbstractVecOrMat},
+    noise_sd::Real,
+    n_features::Int,
+    batch_sizes::Dict,
+    io_pairs::PairedDataContainer,
+)
+
+    regularizer = noise_sd^2
+    n_train = Int(floor(0.8 * size(get_inputs(io_pairs), 2))) # 80:20 train test
+    n_test = size(get_inputs(io_pairs), 2) - n_train
+
+    # split data into train/test randomly
+    itrain = get_inputs(io_pairs)[:, 1:n_train]
+    otrain = get_outputs(io_pairs)[:, 1:n_train]
+    io_train_cost = PairedDataContainer(itrain, otrain)
+    itest = get_inputs(io_pairs)[:, (n_train + 1):end]
+    otest = get_outputs(io_pairs)[:, (n_train + 1):end]
+    input_dim = size(itrain, 1)
+    output_dim = size(otrain, 1)
+
+    # build and fit the RF
+    rfm = RFM_from_hyperparameters(rng, l, regularizer, n_features, batch_sizes, input_dim, output_dim)
+    fitted_features = fit(rfm, io_train_cost, decomposition_type = "svd")
+
+    test_batch_size = get_batch_size(rfm, "test")
+    batch_inputs = batch_generator(itest, test_batch_size, dims = 2) # input_dim x batch_size
+
+    #we want to calc 1/var(y-mean)^2 + lambda/m * coeffs^2 in the end
+    pred_mean, pred_cov = predict(rfm, fitted_features, DataContainer(itest))
+    # sizes (output_dim x n_test), (output_dim x output_dim x n_test) 
+    scaled_coeffs = sqrt(1 / n_features) * get_coeffs(fitted_features)
+
+    return pred_mean, pred_cov, scaled_coeffs
+
+end
+
+
+function estimate_mean_and_coeffnorm_covariance(
+    rng::AbstractRNG,
+    l::Union{Real, AbstractVecOrMat},
+    noise_sd::Real,
+    n_features::Int,
+    batch_sizes::Dict,
+    io_pairs::PairedDataContainer,
+    n_samples::Int;
+    repeats::Int = 1,
+)
+    n_train = Int(floor(0.8 * size(get_inputs(io_pairs), 2))) # 80:20 train test
+    n_test = size(get_inputs(io_pairs), 2) - n_train
+    output_dim = size(get_outputs(io_pairs), 1)
+    means = zeros(n_test, n_samples, output_dim)
+    covs = zeros(n_test, n_samples, output_dim, output_dim)
+    coeffl2norm = zeros(1, n_samples)
+    for i in 1:n_samples
+        for j in 1:repeats
+            m, v, c = calculate_mean_cov_and_coeffs(rng, l, noise_sd, n_features, batch_sizes, io_pairs)
+            # m output_dim x n_test
+            # v output_dim x output_dim x n_test
+            # c n_features
+            means[:, i, :] += m' ./ repeats
+            covs[:, i, :, :] += permutedims(v, (3, 1, 2)) ./ repeats
+            coeffl2norm[1, i] += sqrt(sum(c .^ 2)) / repeats
+        end
+    end
+    blockcovmat = zeros(n_samples, n_test * output_dim, n_test * output_dim)
+    blockmeans = zeros(n_test * output_dim, n_samples)
+    for i in 1:n_test
+        id = ((i - 1) * output_dim + 1):(i * output_dim)
+        blockcovmat[:, id, id] = covs[i, :, :, :] # this ordering, so we can take a mean/cov in dims = 2.
+        blockmeans[id, :] = permutedims(means[i, :, :], (2, 1))
+    end
+
+    Γ = cov(vcat(blockmeans, coeffl2norm), dims = 2)
+    approx_σ2 = mean(blockcovmat, dims = 1)[1, :, :] # approx of \sigma^2I +rf var
+    #symmeterize
+    approx_σ2 = 0.5 * (approx_σ2 + permutedims(approx_σ2, (2, 1)))
+
+    return Γ, approx_σ2
+
+end
+
+function calculate_ensemble_mean_and_coeffnorm(
+    rng::AbstractRNG,
+    lvecormat::AbstractVecOrMat,
+    noise_sd::Real,
+    n_features::Int,
+    batch_sizes::Dict,
+    io_pairs::PairedDataContainer;
+    repeats::Int = 1,
+)
+    if isa(lvecormat, AbstractVector)
+        lmat = reshape(lvecormat, 1, :)
+    else
+        lmat = lvecormat
+    end
+    N_ens = size(lmat, 2)
+    n_train = Int(floor(0.8 * size(get_inputs(io_pairs), 2))) # 80:20 train test
+    n_test = size(get_inputs(io_pairs), 2) - n_train
+    output_dim = size(get_outputs(io_pairs), 1)
+
+    means = zeros(n_test, N_ens, output_dim)
+    covs = zeros(n_test, N_ens, output_dim, output_dim)
+    coeffl2norm = zeros(1, N_ens)
+    for i in collect(1:N_ens)
+        for j in collect(1:repeats)
+            l = lmat[:, i]
+            m, v, c = calculate_mean_cov_and_coeffs(rng, l, noise_sd, n_features, batch_sizes, io_pairs)
+            # m output_dim x n_test
+            # v output_dim x output_dim x n_test
+            # c n_features
+            means[:, i, :] += m' ./ repeats
+            covs[:, i, :, :] += permutedims(v, (3, 1, 2)) ./ repeats
+            coeffl2norm[1, i] += sqrt(sum(c .^ 2)) / repeats
+        end
+    end
+    blockcovmat = zeros(N_ens, n_test * output_dim, n_test * output_dim)
+    blockmeans = zeros(n_test * output_dim, N_ens)
+    for i in 1:n_test
+        id = ((i - 1) * output_dim + 1):(i * output_dim)
+        blockcovmat[:, id, id] = covs[i, :, :, :]
+        blockmeans[id, :] = permutedims(means[i, :, :], (2, 1))
+    end
+    blockcovmat = mean(blockcovmat, dims = 1)[1, :, :] # np x np
+
+    #symmeterize
+    blockcovmat = 0.5 * (blockcovmat + permutedims(blockcovmat, (2, 1)))
+
+
+    return vcat(blockmeans, coeffl2norm), blockcovmat
+
+end
+
+## Begin Script, define problem setting
+println("Begin script")
+date_of_run = Date(2022, 11, 11)
+
+input_dim = 1
+output_dim = 2
+println("Number of output dimensions: ", output_dim)
+
+function ftest_1d_to_2d(x::AbstractMatrix)
+    out = zeros(2, size(x, 2))
+    out[1, :] = mapslices(column -> sin(norm([i * c for (i, c) in enumerate(column)])^2), x, dims = 1)
+    out[2, :] = mapslices(column -> exp(-0.1 * norm([i * c for (i, c) in enumerate(column)])^2), x, dims = 1)
+    return out
+end
+
+#problem formulation
+n_data = 50
+x = rand(rng, MvNormal(zeros(input_dim), I), n_data)
+noise_sd = 1e-1
+lambda = noise_sd^2
+noise = rand(rng, Normal(0, noise_sd), (output_dim, n_data))
+
+y = ftest_1d_to_2d(x) + noise
+io_pairs = PairedDataContainer(x, y)
+
+## Define Hyperpriors for EKP
+
+μ_l = 5.0
+σ_l = 10.0
+# prior for non radial problem
+prior_lengthscale = constrained_gaussian("lengthscale", μ_l, σ_l, 0.0, Inf, repeats = input_dim + output_dim)
+priors = prior_lengthscale
+
+
+# estimate the noise from running many RFM sample costs at the mean values
+batch_sizes = Dict("train" => 600, "test" => 600, "feature" => 600)
+n_train = Int(floor(0.8 * n_data))
+n_test = n_data - n_train
+n_features = Int(floor(1.2 * n_data))
+# RF will perform poorly when n_features is close to n_train
+@assert(!(n_features == n_train)) #
+
+repeats = 1
+
+CALC_TRUTH = true
+
+println("RHKS norm type: norm of coefficients")
+
+if CALC_TRUTH
+    sample_multiplier = 2
+
+    n_samples = (n_test * output_dim + 2) * sample_multiplier
+    println("Estimating output covariance with ", n_samples, " samples")
+    internal_Γ, approx_σ2 = estimate_mean_and_coeffnorm_covariance(
+        rng,
+        repeat([μ_l], input_dim + output_dim), # take mean values
+        noise_sd,
+        n_features,
+        batch_sizes,
+        io_pairs,
+        n_samples,
+        repeats = repeats,
+    )
+
+
+    save("calculated_truth_cov.jld2", "internal_Γ", internal_Γ)
+else
+    println("Loading truth covariance from file...")
+    internal_Γ = load("calculated_truth_cov.jld2")["internal_Γ"]
+end
+
+Γ = internal_Γ
+Γ[1:(n_test * output_dim), 1:(n_test * output_dim)] += approx_σ2
+#    Γ[(n_test + 1):(2 * n_test), (n_test + 1):(2 * n_test)] += I
+Γ[(n_test * output_dim + 1):end, (n_test * output_dim + 1):end] += I
+println(
+    "Estimated variance. Tr(cov) = ",
+    tr(Γ[1:n_test, 1:n_test]),
+    " + ",
+    tr(Γ[(n_test * output_dim + 1):end, (n_test * output_dim + 1):end]),
+)
+#println("noise in observations: ", Γ)
+# Create EKI
+N_ens = 10 * input_dim
+N_iter = 30
+update_cov_step = Inf
+
+initial_params = construct_initial_ensemble(priors, N_ens; rng_seed = ekp_seed)
+params_init = transform_unconstrained_to_constrained(priors, initial_params)#[1, :]
+println("Prior gives parameters between: [$(minimum(params_init)),$(maximum(params_init))]")
+data = vcat(reshape(y[:, (n_train + 1):end], :, 1), 0.0) #flatten data
+
+ekiobj = [EKP.EnsembleKalmanProcess(initial_params, data[:], Γ, Inversion())]
+err = zeros(N_iter)
+println("Begin EKI iterations:")
+Δt = [1.0]
+
+for i in 1:N_iter
+
+    #get parameters:
+    lvec = transform_unconstrained_to_constrained(priors, get_u_final(ekiobj[1]))
+    g_ens, _ =
+        calculate_ensemble_mean_and_coeffnorm(rng, lvec, noise_sd, n_features, batch_sizes, io_pairs, repeats = repeats)
+
+    if i % update_cov_step == 0 # one update to the 
+
+        constrained_u = transform_unconstrained_to_constrained(priors, get_u_final(ekiobj[1]))
+        println("Estimating output covariance with ", n_samples, " samples")
+        internal_Γ_new, approx_σ2_new = estimate_mean_and_coeffnorm_covariance(
+            rng,
+            mean(constrained_u, dims = 2)[:, 1], # take mean values
+            noise_sd,
+            n_features,
+            batch_sizes,
+            io_pairs,
+            n_samples,
+            repeats = repeats,
+        )
+        Γ_new = internal_Γ_new
+        Γ_new[1:(n_test * output_dim), 1:(n_test * output_dim)] += approx_σ2_new
+        #            Γ_new[(n_test + 1):(2 * n_test), (n_test + 1):(2 * n_test)] += I
+        Γ_new[(n_test * output_dim + 1):end, (n_test * output_dim + 1):end] += I
+        println(
+            "Estimated variance. Tr(cov) = ",
+            tr(Γ_new[1:n_test, 1:n_test]),
+            " + ",
+            tr(Γ_new[(n_test * output_dim + 1):end, (n_test * output_dim + 1):end]),
+        )
+
+        ekiobj[1] = EKP.EnsembleKalmanProcess(get_u_final(ekiobj[1]), data, Γ_new, Inversion())
+
+    end
+
+    EKP.update_ensemble!(ekiobj[1], g_ens, Δt_new = Δt[1])
+    err[i] = get_error(ekiobj[1])[end] #mean((params_true - mean(params_i,dims=2)).^2)
+    constrained_u = transform_unconstrained_to_constrained(priors, get_u_final(ekiobj[1]))
+    println(
+        "Iteration: " *
+        string(i) *
+        ", Error: " *
+        string(err[i]) *
+        ", for parameter means: \n" *
+        string(mean(constrained_u, dims = 2)),
+        "\n and sd :\n" * string(sqrt.(var(constrained_u, dims = 2))),
+    )
+    Δt[1] *= 1.0
+end
+
+#run actual experiment
+# override following parameters for actual run
+n_data_test = 100 * input_dim
+n_features_test = Int(floor(1.2 * n_data_test))
+println("number of training data: ", n_data_test)
+println("number of features: ", n_features_test)
+x_test = rand(rng, MvNormal(zeros(input_dim), 0.5 * I), n_data_test)
+noise_test = rand(rng, Normal(0, noise_sd), (output_dim, n_data_test))
+
+y_test = ftest_1d_to_2d(x_test) + noise_test
+io_pairs_test = PairedDataContainer(x_test, y_test)
+
+# get feature distribution
+final_lvec = get_ϕ_mean_final(priors, ekiobj[1])
+println("**********")
+println("Optimal lengthscales: $(final_lvec)")
+println("**********")
+
+μ_c = 0.0
+if size(final_lvec, 1) == 1
+    σ_c = repeat([final_lvec[1, 1]], input_dim)
+    σ_o = repeat([final_lvec[1, 1]], output_dim)
+else
+    σ_c = final_lvec[1:input_dim, 1]
+    σ_o = final_lvec[(input_dim + 1):end, 1]
+end
+regularizer = noise_sd^2
+
+
+M = zeros(input_dim, output_dim) # n x p mean
+U = Diagonal(σ_c) # input covariance
+V = Diagonal(σ_o) # output covariance
+dist = MatrixNormal(M, U, V)
+pd = ParameterDistribution(
+    Dict(
+        "distribution" => Parameterized(dist),
+        "constraint" => repeat([no_constraint()], input_dim * output_dim),
+        "name" => "xi",
+    ),
+)
+feature_sampler = FeatureSampler(pd, output_dim, rng = copy(rng))
+vff = VectorFourierFeature(n_features, output_dim, feature_sampler)
+
+#second case with batching
+
+rfm = RandomFeatureMethod(vff, batch_sizes = batch_sizes, regularization = regularizer)
+fitted_features = fit(rfm, io_pairs_test, decomposition_type = "svd")
+
+if PLOT_FLAG
+    # learning on Normal(0,1) dist, forecast on (-2,2)
+    xrange = reshape(collect(-2:0.02:2), 1, :)
+
+    yrange = ftest_1d_to_2d(xrange)
+
+    pred_mean_slice, pred_cov_slice = predict(rfm, fitted_features, DataContainer(xrange))
+
+    pred_cov_slice[1, 1, :] = max.(pred_cov_slice[1, 1, :], 0.0)
+    pred_cov_slice[2, 2, :] = max.(pred_cov_slice[2, 2, :], 0.0)#plot slice through one dimensions, others fixed to 0
+    figure_save_directory = joinpath(@__DIR__, "output", string(date_of_run))
+    if !isdir(figure_save_directory)
+        mkpath(figure_save_directory)
+    end
+
+    #plot diagonal
+    xplot = xrange[:]
+    plt = plot(
+        xplot,
+        yrange[1, :],
+        show = false,
+        color = "black",
+        linewidth = 5,
+        size = (600, 600),
+        legend = :topleft,
+        label = "Target",
+    )
+    plot!(
+        xplot,
+        yrange[2, :],
+        show = false,
+        color = "black",
+        linewidth = 5,
+        size = (600, 600),
+        legend = :topleft,
+        label = "Target",
+    )
+    scatter!(x_test[:], y_test[1, :], color = "blue", label = "", marker = :x)
+
+    plot!(
+        xplot,
+        pred_mean_slice[1, :],
+        ribbon = [2 * sqrt.(pred_cov_slice[1, 1, :]); 2 * sqrt.(pred_cov_slice[1, 1, :])],
+        label = "Fourier",
+        color = "blue",
+    )
+    scatter!(x_test[:], y_test[2, :], color = "red", label = "", marker = :x)
+    plot!(
+        xplot,
+        pred_mean_slice[2, :],
+        ribbon = [2 * sqrt.(pred_cov_slice[2, 2, :]); 2 * sqrt.(pred_cov_slice[2, 2, :])],
+        label = "Fourier",
+        color = "red",
+    )
+
+    savefig(plt, joinpath(figure_save_directory, "Fit_and_predict_1D_to_MD.pdf"))
+    savefig(plt, joinpath(figure_save_directory, "Fit_and_predict_1D_to_MD.png"))
+
+
+
+end

--- a/src/Features.jl
+++ b/src/Features.jl
@@ -1,17 +1,19 @@
 module Features
 
 include("ScalarFunctions.jl")
-
 import StatsBase: sample
 
-using EnsembleKalmanProcesses.ParameterDistributions, DocStringExtensions, RandomFeatures.Samplers
-
-export RandomFeature, ScalarFeature, ScalarFourierFeature, ScalarNeuronFeature
-
-export sample,
-    get_scalar_function, get_feature_sampler, get_feature_sample, get_n_features, build_features, get_feature_parameters
+using EnsembleKalmanProcesses.ParameterDistributions, DocStringExtensions, RandomFeatures.Samplers, Tullio
 
 abstract type RandomFeature end
+include("ScalarFeatures.jl")
+include("VectorFeatures.jl")
+export RandomFeature
+
+
+export sample,
+    get_scalar_function, get_feature_sampler, get_feature_sample, get_n_features, get_feature_parameters, get_output_dim
+
 
 """
 $(TYPEDSIGNATURES)
@@ -22,77 +24,6 @@ function sample(rf::RandomFeature)
     sampler = get_feature_sampler(rf)
     m = get_n_features(rf)
     return sample(sampler, m)
-end
-
-
-"""
-$(TYPEDEF)
-
-Contains information to build and sample RandomFeatures mapping from N-D -> 1-D
-
-$(TYPEDFIELDS)
-"""
-struct ScalarFeature <: RandomFeature
-    "Number of features"
-    n_features::Int
-    "Sampler of the feature distribution"
-    feature_sampler::Sampler
-    "ScalarFunction mapping R -> R"
-    scalar_function::ScalarFunction
-    "Current `Sample` from sampler"
-    feature_sample::ParameterDistribution
-    "hyperparameters in Feature (and not in Sampler)"
-    feature_parameters::Union{Dict, Nothing}
-end
-
-# common constructors
-"""
-$(TYPEDSIGNATURES)
-
-basic constructor for a `ScalarFeature'
-"""
-function ScalarFeature(
-    n_features::Int,
-    feature_sampler::Sampler,
-    scalar_fun::ScalarFunction;
-    feature_parameters::Dict = Dict("sigma" => 1),
-)
-    if "xi" ∉ get_name(get_parameter_distribution(feature_sampler))
-        throw(
-            ArgumentError(
-                " Named parameter \"xi\" not found in names of parameter_distribution. " *
-                " \n Please provide the name \"xi\" to the distribution used to sample the features",
-            ),
-        )
-    end
-
-    if "sigma" ∉ keys(feature_parameters)
-        @info(" Required feature parameter key \"sigma\" not defined, continuing with default value \"sigma\" = 1 ")
-        feature_parameters["sigma"] = 1.0
-    end
-
-    samp = sample(feature_sampler, n_features)
-
-    return ScalarFeature(n_features, feature_sampler, scalar_fun, samp, feature_parameters)
-end
-
-#these call the above constructor
-"""
-$(TYPEDSIGNATURES)
-
-Constructor for a `Sampler` with cosine features
-"""
-function ScalarFourierFeature(n_features::Int, sampler::Sampler; feature_parameters::Dict = Dict("sigma" => sqrt(2.0)))
-    return ScalarFeature(n_features, sampler, Cosine(); feature_parameters = feature_parameters)
-end
-
-"""
-$(TYPEDSIGNATURES)
-
-Constructor for a `Sampler` with activation-function features
-"""
-function ScalarNeuronFeature(n_features::Int, sampler::Sampler; activation_fun::ScalarActivation = Relu(), kwargs...)
-    return ScalarFeature(n_features, sampler, activation_fun; kwargs...)
 end
 
 # methods
@@ -108,7 +39,7 @@ $(TYPEDSIGNATURES)
 
 gets the `scalar_function` field 
 """
-get_scalar_function(rf::ScalarFeature) = rf.scalar_function
+get_scalar_function(rf::RandomFeature) = rf.scalar_function
 
 """
 $(TYPEDSIGNATURES)
@@ -131,40 +62,6 @@ gets the `feature_parameters` field
 """
 get_feature_parameters(rf::RandomFeature) = rf.feature_parameters
 
-
-"""
-$(TYPEDSIGNATURES)
-
-builds features (possibly batched) from an input matrix of size (input dimension,number of samples)
-"""
-function build_features(
-    rf::ScalarFeature,
-    inputs_t::AbstractMatrix, # input_dim x n_sample
-    batch_feature_idx::AbstractVector{Int},
-)
-    inputs = permutedims(inputs_t, (2, 1)) # n_sample x input_dim
-
-    # build: sigma * sqrt(2) * scalar_function(xi . input + b)
-    samp = get_feature_sample(rf)
-    xi = get_distribution(samp)["xi"] # dim_inputs x n_features
-    features = inputs * xi[:, batch_feature_idx] # n_samples x n_features
-
-    is_uniform_shift = "uniform" ∈ get_name(samp)
-    if is_uniform_shift
-        uniform = get_distribution(samp)["uniform"] # 1 x n_features
-        features .+= uniform[:, batch_feature_idx]
-    end
-
-    sf = get_scalar_function(rf)
-    features = apply_scalar_function(sf, features)
-
-    sigma = get_feature_parameters(rf)["sigma"] # scalar
-    features *= sigma
-
-    return features # n
-end
-
-build_features(rf::ScalarFeature, inputs::AbstractMatrix) = build_features(rf, inputs, collect(1:get_n_features(rf)))
 
 
 end #module

--- a/src/Samplers.jl
+++ b/src/Samplers.jl
@@ -4,7 +4,7 @@ import StatsBase: sample
 
 using Random, Distributions, DocStringExtensions, EnsembleKalmanProcesses.ParameterDistributions
 
-export Sampler, FeatureSampler, get_parameter_distribution, get_uniform_shift_bounds, get_rng, sample
+export Sampler, FeatureSampler, get_parameter_distribution, get_rng, sample
 
 """
 $(TYPEDEF)
@@ -16,8 +16,6 @@ $(TYPEDFIELDS)
 struct Sampler
     "A probability distribution, possibly with constraints"
     parameter_distribution::ParameterDistribution
-    "Either `nothing` , or `[lower bound, upper bound]`, which defines a uniform distribution used as a random shift"
-    uniform_shift_bounds::Union{AbstractVector, Nothing}
     "A random number generator state"
     rng::AbstractRNG
 end
@@ -28,31 +26,54 @@ $(TYPEDSIGNATURES)
 basic constructor for a `Sampler` 
 """
 function FeatureSampler(
-    parameter_distribution::ParameterDistribution;
-    uniform_shift_bounds::Union{AbstractVector, Nothing} = [0, 2 * pi],
+    parameter_distribution::ParameterDistribution,
+    bias_distribution::Union{ParameterDistribution, Nothing};
+    rng::AbstractRNG = Random.GLOBAL_RNG,
+)
+    if isnothing(bias_distribution) # no bias
+        return Sampler(parameter_distribution, rng)
+    else
+        pd = combine_distributions([parameter_distribution, bias_distribution])
+        return Sampler(pd, rng)
+    end
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+one can conveniently specify the bias as a uniform-shift `uniform_shift_bounds` with `output_dim` dimensions
+"""
+function FeatureSampler(
+    parameter_distribution::ParameterDistribution,
+    output_dim::Int;
+    uniform_shift_bounds::AbstractVector = [0, 2 * pi],
     rng::AbstractRNG = Random.GLOBAL_RNG,
 )
 
     # adds a uniform distribution to the parameter distribution
-    if isa(uniform_shift_bounds, AbstractVector)
-        if length(uniform_shift_bounds) == 2
-            unif_pd = ParameterDistribution(
-                Dict(
-                    "distribution" => Parameterized(Uniform(uniform_shift_bounds[1], uniform_shift_bounds[2])),
-                    "constraint" => no_constraint(),
-                    "name" => "uniform",
-                ),
-            )
-            pd = combine_distributions([parameter_distribution, unif_pd])
-        end
+    if output_dim == 1
+        unif_dict = Dict(
+            "distribution" => Parameterized(Uniform(uniform_shift_bounds[1], uniform_shift_bounds[2])),
+            "constraint" => no_constraint(),
+            "name" => "bias",
+        )
     else
-        pd = parameter_distribution
-        uniform_shift_bounds = nothing
+        unif_dict = Dict(
+            "distribution" => VectorOfParameterized(
+                repeat([Uniform(uniform_shift_bounds[1], uniform_shift_bounds[2])], output_dim),
+            ),
+            "constraint" => repeat([no_constraint()], output_dim),
+            "name" => "bias",
+        )
     end
+    unif_pd = ParameterDistribution(unif_dict)
 
-    return Sampler(pd, uniform_shift_bounds, rng)
-
+    pd = combine_distributions([parameter_distribution, unif_pd])
+    return Sampler(pd, rng)
 end
+
+FeatureSampler(parameter_distribution::ParameterDistribution; kwargs...) =
+    FeatureSampler(parameter_distribution, 1; kwargs...)
 
 """
 $(TYPEDSIGNATURES)
@@ -60,13 +81,6 @@ $(TYPEDSIGNATURES)
 gets the `parameter_distribution` field 
 """
 get_parameter_distribution(s::Sampler) = s.parameter_distribution
-
-"""
-$(TYPEDSIGNATURES)
-
-gets the `uniform_shift_bounds` field 
-"""
-get_uniform_shift_bounds(s::Sampler) = s.uniform_shift_bounds
 
 """
 $(TYPEDSIGNATURES)
@@ -82,11 +96,23 @@ samples the distribution within `s`, `n_draws` times using a random number gener
 """
 function sample(rng::AbstractRNG, s::Sampler, n_draws::Int)
     pd = get_parameter_distribution(s)
-    samp = sample(rng, pd, n_draws)
+    # TODO: Support for Matrix Distributions, Flattening them for now.
+    # until EKP.ParameterDistributions we sample Julia distributions directly
+    if any([length(size(get_distribution(d))) > 1 for d in pd.distribution])
+        # get [ [in x out] x samples, [out x samples]]
+        samps = [sample(rng, d, n_draws) for d in pd.distribution]
+        samp_xi = cat(samps[1]..., dims = 3) # [in x out x samples]
+        samp_xi = reshape(samp_xi, size(samp_xi, 1) * size(samp_xi, 2), size(samp_xi, 3)) # stacks in+in+... to make a  (in x out) x samples
+        samp_bias = samps[2] # out x samples 
+        samp = cat(samp_xi, samp_bias, dims = 1) # (in x out + out) x 20
+    else
+        samp = cat([sample(rng, d, n_draws) for d in pd.distribution]..., dims = 1)
+    end
+    #samp = sample(rng, pd, n_draws) # vec(univariate), mat(multivariate) or vec of mats (matrixvariate)
     constrained_samp = transform_unconstrained_to_constrained(pd, samp)
     #now create a Samples-type distribution from the samples
     s_names = get_name(pd)
-    s_slices = batch(pd) # e.g., [1, 2:3, 4:9]
+    s_slices = batch(pd) # e.g.,"xi","bias" [1:3,4:6]
     s_samples = [Samples(constrained_samp[slice, :]) for slice in s_slices]
     s_constraints = [repeat([no_constraint()], size(slice, 1)) for slice in s_slices]
 

--- a/src/ScalarFeatures.jl
+++ b/src/ScalarFeatures.jl
@@ -1,0 +1,116 @@
+export ScalarFeature, ScalarFourierFeature, ScalarNeuronFeature
+export build_features
+
+"""
+$(TYPEDEF)
+
+Contains information to build and sample RandomFeatures mapping from N-D -> 1-D
+
+$(TYPEDFIELDS)
+"""
+struct ScalarFeature <: RandomFeature
+    "Number of features"
+    n_features::Int
+    "Sampler of the feature distribution"
+    feature_sampler::Sampler
+    "ScalarFunction mapping R -> R"
+    scalar_function::ScalarFunction
+    "Current `Sample` from sampler"
+    feature_sample::ParameterDistribution
+    "hyperparameters in Feature (and not in Sampler)"
+    feature_parameters::Union{Dict, Nothing}
+end
+
+# common constructors
+"""
+$(TYPEDSIGNATURES)
+
+basic constructor for a `ScalarFeature'
+"""
+function ScalarFeature(
+    n_features::Int,
+    feature_sampler::Sampler,
+    scalar_fun::ScalarFunction;
+    feature_parameters::Dict = Dict("sigma" => 1),
+)
+    if "xi" ∉ get_name(get_parameter_distribution(feature_sampler))
+        throw(
+            ArgumentError(
+                " Named parameter \"xi\" not found in names of parameter_distribution. " *
+                " \n Please provide the name \"xi\" to the distribution used to sample the features",
+            ),
+        )
+    end
+
+    if "sigma" ∉ keys(feature_parameters)
+        @info(" Required feature parameter key \"sigma\" not defined, continuing with default value \"sigma\" = 1 ")
+        feature_parameters["sigma"] = 1.0
+    end
+
+    samp = sample(feature_sampler, n_features)
+
+    return ScalarFeature(n_features, feature_sampler, scalar_fun, samp, feature_parameters)
+end
+
+#these call the above constructor
+"""
+$(TYPEDSIGNATURES)
+
+Constructor for a `ScalarFeature` with cosine features
+"""
+function ScalarFourierFeature(n_features::Int, sampler::Sampler; feature_parameters::Dict = Dict("sigma" => sqrt(2.0)))
+    return ScalarFeature(n_features, sampler, Cosine(); feature_parameters = feature_parameters)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Constructor for a `ScalarFeature` with activation-function features (default ReLU)
+"""
+function ScalarNeuronFeature(n_features::Int, sampler::Sampler; activation_fun::ScalarActivation = Relu(), kwargs...)
+    return ScalarFeature(n_features, sampler, activation_fun; kwargs...)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+builds features (possibly batched) from an input matrix of size (input dimension, number of samples) output of dimension (number of samples, 1, number features) 
+"""
+function build_features(
+    rf::ScalarFeature,
+    inputs::AbstractMatrix, # input_dim x n_sample
+    batch_feature_idx::AbstractVector{Int},
+)
+    #    inputs = permutedims(inputs_t, (2, 1)) # n_sample x input_dim
+
+    # build: sigma * scalar_function(xi . input + b)
+    samp = get_feature_sample(rf)
+    xi = get_distribution(samp)["xi"][:, batch_feature_idx] # dim_inputs x n_features
+    #    features = inputs * xi[:, batch_feature_idx] # n_samples x n_features
+    @tullio features[n, b] := inputs[d, n] * xi[d, b] # n_samples x output_dim x n_feature_batch
+
+    is_biased = "bias" ∈ get_name(samp)
+    if is_biased
+        bias = get_distribution(samp)["bias"][1, batch_feature_idx] # 1 x n_features
+        #        features .+= bias[:, batch_feature_idx]
+        @tullio features[n, b] += bias[b]
+    end
+
+    sf = get_scalar_function(rf)
+    features = apply_scalar_function(sf, features)
+
+    sigma = get_feature_parameters(rf)["sigma"] # scalar
+    features *= sigma
+
+    #consistent output shape with vector case, by putting output_dim = 1 in middle dimension
+    return reshape(features, size(features, 1), 1, size(features, 2))
+end
+
+build_features(rf::ScalarFeature, inputs::AbstractMatrix) = build_features(rf, inputs, collect(1:get_n_features(rf)))
+
+"""
+$(TYPEDSIGNATURES)
+
+gets the output dimension (equals 1 for scalar-valued features)
+"""
+get_output_dim(rf::ScalarFeature) = 1

--- a/src/ScalarFunctions.jl
+++ b/src/ScalarFunctions.jl
@@ -36,7 +36,7 @@ $(TYPEDSIGNATURES)
 
 apply the scalar function `sf` pointwise to vectors or matrices
 """
-apply_scalar_function(sf::ScalarFunction, r::AbstractVecOrMat) = apply_scalar_function.(Ref(sf), r) # Ref(sf) treats sf as a scalar for the broadcasting
+apply_scalar_function(sf::ScalarFunction, r::AbstractArray) = apply_scalar_function.(Ref(sf), r) # Ref(sf) treats sf as a scalar for the broadcasting
 
 """
 $(TYPEDEF)

--- a/src/VectorFeatures.jl
+++ b/src/VectorFeatures.jl
@@ -1,0 +1,135 @@
+export VectorFeature, VectorFourierFeature, VectorNeuronFeature
+export build_features
+
+"""
+$(TYPEDEF)
+
+Contains information to build and sample RandomFeatures mapping from N-D -> M-D
+
+$(TYPEDFIELDS)
+"""
+struct VectorFeature <: RandomFeature
+    "Number of features"
+    n_features::Int
+    "Dimension of output"
+    output_dim::Int
+    "Sampler of the feature distribution"
+    feature_sampler::Sampler
+    "ScalarFunction mapping R -> R"
+    scalar_function::ScalarFunction
+    "Current `Sample` from sampler"
+    feature_sample::ParameterDistribution
+    "hyperparameters in Feature (and not in Sampler)"
+    feature_parameters::Union{Dict, Nothing}
+end
+
+# common constructors
+"""
+$(TYPEDSIGNATURES)
+
+basic constructor for a `VectorFeature'
+"""
+function VectorFeature(
+    n_features::Int,
+    output_dim::Int,
+    feature_sampler::Sampler,
+    scalar_fun::ScalarFunction;
+    feature_parameters::Dict = Dict("sigma" => 1),
+)
+
+    if "xi" ∉ get_name(get_parameter_distribution(feature_sampler))
+        throw(
+            ArgumentError(
+                " Named parameter \"xi\" not found in names of parameter_distribution. " *
+                " \n Please provide the name \"xi\" to the distribution used to sample the features",
+            ),
+        )
+    end
+
+    if "sigma" ∉ keys(feature_parameters)
+        @info(" Required feature parameter key \"sigma\" not defined, continuing with default value \"sigma\" = 1 ")
+        feature_parameters["sigma"] = 1.0
+    end
+
+    samp = sample(feature_sampler, n_features)
+
+    return VectorFeature(n_features, output_dim, feature_sampler, scalar_fun, samp, feature_parameters)
+end
+
+#these call the above constructor
+"""
+$(TYPEDSIGNATURES)
+
+Constructor for a `VectorFeature` with cosine features
+"""
+function VectorFourierFeature(
+    n_features::Int,
+    output_dim::Int,
+    sampler::Sampler;
+    feature_parameters::Dict = Dict("sigma" => sqrt(2.0)),
+)
+    return VectorFeature(n_features, output_dim, sampler, Cosine(); feature_parameters = feature_parameters)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Constructor for a `VectorFeature` with activation-function features (default ReLU)
+"""
+function VectorNeuronFeature(
+    n_features::Int,
+    output_dim::Int,
+    sampler::Sampler;
+    activation_fun::ScalarActivation = Relu(),
+    kwargs...,
+)
+    return VectorFeature(n_features, output_dim, sampler, activation_fun; kwargs...)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+builds features (possibly batched) from an input matrix of size (input dimension,number of samples) output of dimension (number of samples, output dimension, number features) 
+"""
+function build_features(
+    rf::VectorFeature,
+    inputs::AbstractMatrix, # input_dim x n_sample
+    batch_feature_idx::AbstractVector{Int},
+)
+    # build: sigma * scalar_function(xi * input + b)
+    samp = get_feature_sample(rf)
+
+    #TODO: What we want:
+    # xi = get_distribution(samp)["xi"][:,:,batch_feature_idx] # input_dim x output_dim x n_feature_batch
+    # for now, as matrix distributions aren't yet supported, xi is flattened, so we reshape
+    xi_flat = get_distribution(samp)["xi"][:, batch_feature_idx] # (input_dim x output_dim) x n_feature_batch
+    sampler = get_feature_sampler(rf)
+    pd = get_parameter_distribution(sampler)
+    xi_size = size(get_distribution(pd)["xi"])
+    xi = reshape(xi_flat, xi_size..., size(xi_flat, 2)) # in x out x n_feature_batch
+
+    @tullio features[n, p, b] := inputs[d, n] * xi[d, p, b] # n_samples x output_dim x n_feature_batch
+
+    is_biased = "bias" ∈ get_name(samp)
+    if is_biased
+        bias = get_distribution(samp)["bias"][:, batch_feature_idx] # dim_output x n_features
+        @tullio features[n, p, b] += bias[p, b]
+    end
+
+    sf = get_scalar_function(rf)
+    features = apply_scalar_function(sf, features)
+
+    sigma = get_feature_parameters(rf)["sigma"] # scalar
+    features *= sigma
+
+    return features # n_sample x n_feature_batch x output_dim
+end
+
+build_features(rf::VectorFeature, inputs::AbstractMatrix) = build_features(rf, inputs, collect(1:get_n_features(rf)))
+
+"""
+$(TYPEDSIGNATURES)
+
+gets the output dimension (equals 1 for scalar-valued features)
+"""
+get_output_dim(rf::VectorFeature) = rf.output_dim

--- a/test/Features/runtests.jl
+++ b/test/Features/runtests.jl
@@ -4,6 +4,7 @@ using StatsBase
 using LinearAlgebra
 using Random
 using Distributions
+using Tullio
 
 using RandomFeatures.ParameterDistributions
 using RandomFeatures.Samplers
@@ -65,7 +66,7 @@ seed = 2202
 
     end
 
-    @testset "Constructors" begin
+    @testset "Scalar: Constructors" begin
 
         n_features = 20
         relu = Relu()
@@ -98,16 +99,16 @@ seed = 2202
         sf_test = ScalarFeature(n_features, feature_sampler, relu)
         @test get_n_features(sf_test) == n_features
         @test get_feature_parameters(sf_test) == Dict("sigma" => 1.0)
+        @test get_output_dim(sf_test) == 1
+        @test get_feature_parameters(sf_test)["sigma"] == sqrt(1)
 
         test_sample = sample(copy(rng), feature_sampler, n_features)
         sf_test_sample = get_feature_sample(sf_test)
-        # cumbersome as distributions can't equate each other with "==" (Issue in EnsembleKalmanProcesses)
         @test get_distribution(sf_test_sample)["xi"] == get_distribution(test_sample)["xi"]
-        @test get_distribution(sf_test_sample)["uniform"] == get_distribution(test_sample)["uniform"]
+        @test get_distribution(sf_test_sample)["bias"] == get_distribution(test_sample)["bias"]
         @test get_all_constraints(sf_test_sample) == get_all_constraints(test_sample)
         @test get_name(sf_test_sample) == get_name(test_sample)
         sf_test_sampler = get_feature_sampler(sf_test)
-        @test get_uniform_shift_bounds(sf_test_sampler) == [0, 2 * pi]
 
 
         sff_test = ScalarFourierFeature(n_features, feature_sampler)
@@ -115,11 +116,12 @@ seed = 2202
         snf_test = ScalarNeuronFeature(n_features, feature_sampler)
 
         @test isa(get_scalar_function(sff_test), Features.Cosine)
+        @test get_feature_parameters(sff_test)["sigma"] == sqrt(2.0)
         @test isa(get_scalar_function(snf_test), Relu)
 
     end
 
-    @testset "build features" begin
+    @testset "Scalar: build features" begin
 
         n_features = 20
         rng = StableRNG(seed)
@@ -144,8 +146,8 @@ seed = 2202
         samp_unif = reshape(rand(rng1, Uniform(0, 2 * pi), n_features), (1, n_features))
         inputs_1d_T = permutedims(inputs_1d, (2, 1))
         rf_test = sigma_value * cos.(inputs_1d_T * samp_xi .+ samp_unif)
-        @test size(features_1d) == (n_samples_1d, n_features)
-        @test all(abs.(rf_test - features_1d) .< 10 * eps()) # sufficiently big to deal with inaccuracy of cosine
+        @test size(features_1d) == (n_samples_1d, 1, n_features) # we store internally with output_dim = 1
+        @test all(abs.(rf_test - features_1d[:, 1, :]) .< 10 * eps()) # sufficiently big to deal with inaccuracy of cosine
 
         # 10D input space -> 1D output space
         # generate a bunch of random samples as data points
@@ -170,9 +172,125 @@ seed = 2202
         samp_unif = reshape(rand(rng2, Uniform(0, 2 * pi), n_features), (1, n_features))
         inputs_10d_T = permutedims(inputs_10d, (2, 1))
         rf_test2 = sigma_value * max.(inputs_10d_T * samp_xi .+ samp_unif, 0)
-        @test size(features_10d) == (n_samples, n_features)
+        @test size(features_10d) == (n_samples, 1, n_features) # we store internall with output_dim = 1
+        @test all(abs.(rf_test2 - features_10d[:, 1, :]) .< 1e3 * eps()) # sufficiently big to deal with inaccuracy of relu
 
-        @test all(abs.(rf_test2 - features_10d) .< 1e3 * eps()) # sufficiently big to deal with inaccuracy of relu
+    end
+
+
+    @testset "Vector: Constructors" begin
+
+        n_features = 20
+        input_dim = 5
+        output_dim = 2
+        relu = Relu()
+        rng = StableRNG(seed)
+
+
+        #just to test error flag
+        μ_c = 0.0
+        σ_c = 2.0
+        pd_err = constrained_gaussian("test", μ_c, σ_c, -Inf, Inf, repeats = output_dim)
+        feature_sampler_err = FeatureSampler(pd_err, output_dim, rng = copy(rng))
+
+        #setup sampler xi distributions:
+        dist = MatrixNormal(zeros(input_dim, output_dim), Diagonal(ones(input_dim)), Diagonal(ones(output_dim))) #produces 5 x 2 matrix samples
+        pd = ParameterDistribution(
+            Dict(
+                "distribution" => Parameterized(dist),
+                "constraint" => repeat([no_constraint()], input_dim * output_dim), #flattened
+                "name" => "xi",
+            ),
+        )
+        feature_sampler = FeatureSampler(pd, output_dim, rng = copy(rng))
+
+        # postive constraints for sigma
+        sigma_fixed_err = Dict("not sigma" => 10.0)
+
+        # Error checks
+        @test_throws ArgumentError VectorFeature(
+            n_features,
+            output_dim,
+            feature_sampler_err, # causes error
+            relu,
+        )
+        @test_logs (
+            :info,
+            " Required feature parameter key \"sigma\" not defined, continuing with default value \"sigma\" = 1 ",
+        ) VectorFeature(n_features, output_dim, feature_sampler, relu, feature_parameters = sigma_fixed_err)
+
+        # VectorFeature and getters
+        feature_sampler = FeatureSampler(pd, output_dim, rng = copy(rng)) # to reset the rng
+        vf_test = VectorFeature(n_features, output_dim, feature_sampler, relu)
+        @test get_n_features(vf_test) == n_features
+        @test get_feature_parameters(vf_test) == Dict("sigma" => 1.0)
+        @test get_output_dim(vf_test) == output_dim
+        @test get_feature_parameters(vf_test)["sigma"] == sqrt(1)
+
+        test_sample = sample(copy(rng), feature_sampler, n_features)
+        vf_test_sample = get_feature_sample(vf_test)
+        @test get_distribution(vf_test_sample)["xi"] == get_distribution(test_sample)["xi"]
+        @test get_distribution(vf_test_sample)["bias"] == get_distribution(test_sample)["bias"]
+        @test get_all_constraints(vf_test_sample) == get_all_constraints(test_sample)
+        @test get_name(vf_test_sample) == get_name(test_sample)
+        vf_test_sampler = get_feature_sampler(vf_test)
+
+        vff_test = VectorFourierFeature(n_features, output_dim, feature_sampler)
+        vnf_test = VectorNeuronFeature(n_features, output_dim, feature_sampler)
+
+        @test isa(get_scalar_function(vff_test), Features.Cosine)
+        @test get_feature_parameters(vff_test)["sigma"] == sqrt(2.0)
+        @test isa(get_scalar_function(vnf_test), Relu)
+
+    end
+
+    @testset "Vector: build features" begin
+
+        n_features = 20
+        input_dim = 5
+        output_dim = 2
+        rng = StableRNG(seed)
+
+        #setup sampler xi distributions:
+        dist = MatrixNormal(zeros(input_dim, output_dim), Diagonal(ones(input_dim)), Diagonal(ones(output_dim))) #produces 5 x 2 matrix samples
+        pd = ParameterDistribution(
+            Dict(
+                "distribution" => Parameterized(dist),
+                "constraint" => repeat([no_constraint()], input_dim * output_dim),
+                "name" => "xi",
+            ),
+        )
+        feature_sampler_5d = FeatureSampler(pd, output_dim, rng = copy(rng))
+
+        sigma_value = 10.0
+        sigma_fixed = Dict("sigma" => sigma_value)
+
+        vff_5d_5d_test =
+            VectorFourierFeature(n_features, output_dim, feature_sampler_5d, feature_parameters = sigma_fixed)
+
+        # 1D input space -> 5D output space
+        n_samples = 200
+        inputs_5d_5d = rand(Uniform(-1, 1), (input_dim, n_samples))
+        features_5d_5d = build_features(vff_5d_5d_test, inputs_5d_5d)
+
+        rng1 = copy(rng)
+        samp_flat = sample(rng1, feature_sampler_5d, n_features)
+        samp_xi_flat = get_distribution(samp_flat)["xi"]
+        # as we flatten the samples currently in the sampler.sample. reshape with dist.
+        xi_size = size(get_distribution(pd)["xi"])
+        samp_xi = reshape(samp_xi_flat, xi_size..., size(samp_xi_flat, 2)) # in x out x n_feature_batch
+
+
+        @tullio features[n, p, b] := inputs_5d_5d[d, n] * samp_xi[d, p, b]
+        #        samp_xi = reshape(sample(rng1, pd, n_features), (2, n_features))
+        samp_bias = get_distribution(samp_flat)["bias"]
+        @tullio features[n, p, b] += samp_bias[p, b]
+
+        #        inputs_5d_5d_T = permutedims(inputs_5d_5d, (2, 1))
+        rf_test = sigma_value * cos.(features)
+        #        rf_test = sigma_value * cos.(inputs_5d_5d_T * samp_xi .+ samp_unif)
+        @test size(features_5d_5d) == (n_samples, output_dim, n_features) # we store internally with output_dim = 1
+        @test all(abs.(rf_test - features_5d_5d) .< 10 * eps()) # sufficiently big to deal with inaccuracy of cosine
 
     end
 

--- a/test/Samplers/runtests.jl
+++ b/test/Samplers/runtests.jl
@@ -19,22 +19,42 @@ seed = 2022
 
     pd = constrained_gaussian("xi", μ_c, σ_c, -Inf, 0.0)
 
-    fsampler = FeatureSampler(pd)
-    @test get_uniform_shift_bounds(fsampler) == [0, 2 * pi]
+    #1d output space
+    fsampler = FeatureSampler(pd) # takes a uniform with shift as the bias
     unif_pd = ParameterDistribution(
-        Dict("distribution" => Parameterized(Uniform(0, 2 * π)), "constraint" => no_constraint(), "name" => "uniform"),
+        Dict("distribution" => Parameterized(Uniform(0, 2 * π)), "constraint" => no_constraint(), "name" => "bias"),
     )
+    fsamplerbias = FeatureSampler(pd, unif_pd)#provide bias distribution explicitly
+
     full_pd = combine_distributions([pd, unif_pd])
 
-    test_full_pd = get_parameter_distribution(fsampler)
-    @test get_distribution(test_full_pd) == get_distribution(full_pd)
-    @test get_all_constraints(test_full_pd) == get_all_constraints(full_pd)
-    @test get_name(test_full_pd) == get_name(full_pd)
+    @test get_parameter_distribution(fsampler) == full_pd
+    @test get_parameter_distribution(fsamplerbias) == full_pd
+
+    #5d input - 3d output-space
+    output_dim = 3
+    pd_3d = constrained_gaussian("xi", μ_c, σ_c, -Inf, 0.0, repeats = 5)
+    fsampler_3d = FeatureSampler(pd_3d, output_dim) # 3d output space
+    unif_pd_3d = ParameterDistribution(
+        Dict(
+            "distribution" => VectorOfParameterized(repeat([Uniform(0, 2 * π)], output_dim)),
+            "constraint" => repeat([no_constraint()], output_dim),
+            "name" => "bias",
+        ),
+    )
+    fsamplerbias_3d = FeatureSampler(pd_3d, unif_pd_3d)#provide bias distribution explicitly
+    full_pd_3d = combine_distributions([pd_3d, unif_pd_3d])
+
+    @test get_parameter_distribution(fsampler_3d) == full_pd_3d
+    @test get_parameter_distribution(fsamplerbias_3d) == full_pd_3d
+
 
     # and other option for settings
-    usb = nothing
-    sampler2 = FeatureSampler(pd, uniform_shift_bounds = usb)
-    @test get_uniform_shift_bounds(sampler2) == usb
+    no_bias = nothing
+    sampler_no_bias = FeatureSampler(pd, no_bias)
+    @test pd == get_parameter_distribution(sampler_no_bias)
+
+
 
     # test method: sample
     function sample_to_Sample(pd::ParameterDistribution, samp::AbstractMatrix)
@@ -54,53 +74,32 @@ seed = 2022
     Random.seed!(seed)
     sample1 = sample(fsampler) # produces a Samples ParameterDistribution
     Random.seed!(seed)
-    test1 = sample_to_Sample(full_pd, sample(full_pd))
-    @test get_distribution(sample1) == get_distribution(test1)
-    @test get_all_constraints(sample1) == get_all_constraints(test1)
-    @test get_name(sample1) == get_name(test1)
+    @test sample1 == sample_to_Sample(full_pd, sample(full_pd))
 
     n_samples = 40
     Random.seed!(seed)
     sample2 = sample(fsampler, n_samples)
     Random.seed!(seed)
-    test2 = sample_to_Sample(full_pd, sample(full_pd, n_samples))
-    @test get_distribution(sample2) == get_distribution(test2)
-    @test get_all_constraints(sample2) == get_all_constraints(test2)
-    @test get_name(sample2) == get_name(test2)
-
+    @test sample2 == sample_to_Sample(full_pd, sample(full_pd, n_samples))
     # now with two explicit rng's
     rng1 = Random.MersenneTwister(seed)
     sampler_rng1 = FeatureSampler(pd, rng = copy(rng1))
     @test get_rng(sampler_rng1) == copy(rng1)
     sample3 = sample(sampler_rng1)
     @test !(get_rng(sampler_rng1) == copy(rng1))
-    test3 = sample_to_Sample(full_pd, sample(copy(rng1), full_pd, 1))
-    @test get_distribution(sample3) == get_distribution(test3)
-    @test get_all_constraints(sample3) == get_all_constraints(test3)
-    @test get_name(sample3) == get_name(test3)
-
+    @test sample3 == sample_to_Sample(full_pd, sample(copy(rng1), full_pd, 1))
 
     sampler_rng1 = FeatureSampler(pd, rng = copy(rng1))
     sample4 = sample(sampler_rng1, n_samples)
-    test4 = sample_to_Sample(full_pd, sample(copy(rng1), full_pd, n_samples))
-    @test get_distribution(sample4) == get_distribution(test4)
-    @test get_all_constraints(sample4) == get_all_constraints(test4)
-    @test get_name(sample4) == get_name(test4)
+    @test sample4 == sample_to_Sample(full_pd, sample(copy(rng1), full_pd, n_samples))
 
     #this time override use rng2 to override the default Random.GLOBAL_RNG at the point of sampling
     rng2 = StableRNG(seed)
     sample5 = sample(copy(rng2), fsampler)
-    test5 = sample_to_Sample(full_pd, sample(copy(rng2), full_pd, 1))
-    @test get_distribution(sample5) == get_distribution(test5)
-    @test get_all_constraints(sample5) == get_all_constraints(test5)
-    @test get_name(sample5) == get_name(test5)
-
+    sample5 == sample_to_Sample(full_pd, sample(copy(rng2), full_pd, 1))
 
     sample6 = sample(copy(rng2), fsampler, n_samples)
-    test6 = sample_to_Sample(full_pd, sample(copy(rng2), full_pd, n_samples))
-    @test get_distribution(sample6) == get_distribution(test6)
-    @test get_all_constraints(sample6) == get_all_constraints(test6)
-    @test get_name(sample6) == get_name(test6)
+    @test sample6 == sample_to_Sample(full_pd, sample(copy(rng2), full_pd, n_samples))
 
 
 end

--- a/test/Utilities/runtests.jl
+++ b/test/Utilities/runtests.jl
@@ -38,9 +38,11 @@ using RandomFeatures.Utilities
     x = [i + j for i in 1:N, j in 1:N]
     x = 1 ./ (x + x') + 1e-3 * I
 
-    b = ones(N)
-
-    xsolve = x \ b
+    # internally RHS are stored with three indices.
+    # (n_features x n_samples, output_dim)
+    b = ones(N, 1, 1)
+    xsolve = zeros(size(b))
+    xsolve[:, 1, 1] = x \ b[:, 1, 1]
 
     xsvd = Decomposition(x, "svd")
     @test get_decomposition(xsvd) == svd(x)
@@ -72,8 +74,9 @@ using RandomFeatures.Utilities
     @test get_full_matrix(ypinv) == y
 
     # to show pinv gets the right solution in a singular problem
-    @test_throws SingularException y \ b
-    ysolve = pinv(y) * b
+    @test_throws SingularException y \ b[:, 1, 1]
+    ysolve = zeros(size(b))
+    ysolve[:, :, 1] = pinv(y) * b[:, :, 1]
     @test linear_solve(ypinv, b) ≈ ysolve
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,7 +15,7 @@ function include_test(_module)
     return nothing
 end
 
-@testset "EnsembleKalmanProcesses" begin
+@testset "RandomFeatures" begin
     all_tests = isempty(ARGS) || "all" in ARGS ? true : false
 
     function has_submodule(sm)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
To extend the scalar random features to vector random features
answers some checkpoints in #1 

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- Added VectorFeature Class, and 
- extended Samplers, linear solvers and random feature methods to deal with 3-tensor structures
- Only a general multi-output random feature so far. (no e.g. separable features)
- hyperparameter learning example 1D->2D  (3 lengthscales) `nd_to_md_regression_direct_withcov.jl`
- Unit test for 1d->2d [with values from hyperparameter example]
![Fit_and_predict_1D_to_2D](https://user-images.githubusercontent.com/47412152/200430820-8709ffcc-d884-492f-bb50-a01af3318efc.png)
- Opened issue regarding compatability of sampling matrix-variate distributions in EnsembleKalmanProcesses.jl #229

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevent documentation.

-->
