### PR TITLE
Accelerations learnt from profiling

### DIFF
--- a/examples/Learn_hyperparameters/nd_to_md_regression_direct_withcov.jl
+++ b/examples/Learn_hyperparameters/nd_to_md_regression_direct_withcov.jl
@@ -26,6 +26,7 @@ using RandomFeatures.Samplers
 using RandomFeatures.Features
 using RandomFeatures.Methods
 using RandomFeatures.Utilities
+using ProfileView
 
 seed = 2024
 ekp_seed = 99999
@@ -43,22 +44,26 @@ function flat_to_chol(x::AbstractArray)
 end
 
 function posdef_correct(mat::AbstractMatrix, tol = 1e8 * eps())
-    out = 0.5 * (mat + permutedims(mat, (2, 1))) #symmetrize
-    out += (abs(minimum(eigvals(out))) + tol) * I #add to diag
-    return out
-
+    mat += permutedims(mat, (2, 1))
+    mat *= 0.5 # symmetrize
+    return mat + (abs(minimum(eigvals(mat))) + tol) * I #add to diag
 end
 
 ## Functions of use
 function RFM_from_hyperparameters(
-    rng::AbstractRNG,
-    l::Union{Real, AbstractVecOrMat},
-    lambda,
+    rng::RNG,
+    l::RorM,
+    lambda::L,
     n_features::Int,
-    batch_sizes::Dict,
+    batch_sizes::Dict{S, Int},
     input_dim::Int,
     output_dim::Int,
-)
+) where {
+    RNG <: AbstractRNG,
+    RorM <: Union{Real, AbstractVecOrMat},
+    S <: AbstractString,
+    L <: Union{AbstractMatrix, UniformScaling, Real},
+}
 
     # l = [input_dim params + output_dim params]
     μ_c = 0.0
@@ -85,9 +90,11 @@ function RFM_from_hyperparameters(
     M = zeros(input_dim, output_dim) # n x p mean
 
     if !isposdef(U)
+        println("U not posdef")
         U = posdef_correct(U)
     end
     if !isposdef(V)
+        println("V not posdef")
         V = posdef_correct(V)
     end
     representation = "covariance" # "covariance"
@@ -95,21 +102,24 @@ function RFM_from_hyperparameters(
         Uinv = inv(U)
         Vinv = inv(V)
         if !isposdef(Uinv)
-            Uinv = posdef_correct(Uinv)
+            println("Uinv not posdef")
+
+            U = posdef_correct(Uinv)
         end
         if !isposdef(Vinv)
-            Vinv = posdef_correct(Vinv)
+            println("Vinv not posdef")
+
+            V = posdef_correct(Vinv)
         end
-        dist = MatrixNormal(M, Uinv, Vinv)
     elseif representation == "covariance"
-        dist = MatrixNormal(M, U, V)
+        nothing
     else
         throw(ArgumentError("representation must be \"covariance\" else \"precision\". Got $representation"))
     end
 
     pd = ParameterDistribution(
         Dict(
-            "distribution" => Parameterized(dist),
+            "distribution" => Parameterized(MatrixNormal(M, U, V)),
             "constraint" => repeat([no_constraint()], input_dim * output_dim),
             "name" => "xi",
         ),
@@ -122,14 +132,22 @@ end
 
 
 function calculate_mean_cov_and_coeffs(
-    rng::AbstractRNG,
-    l::Union{Real, AbstractVecOrMat},
-    lambda,
+    rng::RNG,
+    l::RorM,
+    lambda::L,
     n_features::Int,
-    batch_sizes::Dict,
+    batch_sizes::Dict{S, Int},
     io_pairs::PairedDataContainer,
-    decomp_type::String = "chol",
-)
+    mean_store::Matrix{FT},
+    cov_store::Array{FT, 3};
+    decomp_type::S = "chol",
+) where {
+    RNG <: AbstractRNG,
+    FT <: AbstractFloat,
+    S <: AbstractString,
+    RorM <: Union{Real, AbstractVecOrMat},
+    L <: Union{AbstractMatrix, UniformScaling, Real},
+}
 
     n_train = Int(floor(0.8 * size(get_inputs(io_pairs), 2))) # 80:20 train test
     n_test = size(get_inputs(io_pairs), 2) - n_train
@@ -150,15 +168,14 @@ function calculate_mean_cov_and_coeffs(
     else
         fitted_features = fit(rfm, io_train_cost, decomposition_type = "svd")
     end
-
     test_batch_size = get_batch_size(rfm, "test")
     batch_inputs = batch_generator(itest, test_batch_size, dims = 2) # input_dim x batch_size
 
     #we want to calc 1/var(y-mean)^2 + lambda/m * coeffs^2 in the end
-    pred_mean, pred_cov = predict(rfm, fitted_features, DataContainer(itest))
+    #    pred_mean, pred_cov = predict(rfm, fitted_features, DataContainer(itest))
+    predict!(rfm, fitted_features, DataContainer(itest), mean_store, cov_store)
     # sizes (output_dim x n_test), (output_dim x output_dim x n_test) 
     scaled_coeffs = sqrt(1 / n_features) * get_coeffs(fitted_features)
-
     reg = get_regularization(fitted_features)
     #    if !isa(reg, UniformScaling)
     #        println("diag of reg: ",diag(reg))
@@ -173,41 +190,65 @@ function calculate_mean_cov_and_coeffs(
     end
     println("sample_complexity", complexity)
 
-    return pred_mean, pred_cov, scaled_coeffs, complexity
+    #    return pred_mean, pred_cov, scaled_coeffs, complexity
+    return scaled_coeffs, complexity
 
 end
 
 
 function estimate_mean_and_coeffnorm_covariance(
-    rng::AbstractRNG,
-    l::Union{Real, AbstractVecOrMat},
-    lambda,
+    rng::RNG,
+    l::RorM,
+    lambda::L,
     n_features::Int,
-    batch_sizes::Dict,
+    batch_sizes::Dict{S, Int},
     io_pairs::PairedDataContainer,
     n_samples::Int;
     repeats::Int = 1,
-)
+) where {
+    RNG <: AbstractRNG,
+    S <: AbstractString,
+    RorM <: Union{Real, AbstractVecOrMat},
+    L <: Union{AbstractMatrix, UniformScaling, Real},
+}
     n_train = Int(floor(0.8 * size(get_inputs(io_pairs), 2))) # 80:20 train test
     n_test = size(get_inputs(io_pairs), 2) - n_train
     output_dim = size(get_outputs(io_pairs), 1)
-    means = zeros(n_test, n_samples, output_dim)
-    covs = zeros(n_test, n_samples, output_dim, output_dim)
+    #    means = zeros(n_test, n_samples, output_dim)
+    #    covs = zeros(n_test, n_samples, output_dim, output_dim)
+    means = zeros(output_dim, n_samples, n_test)
+    covs = zeros(output_dim, n_samples, output_dim, n_test)
     complexity = zeros(1, n_samples)
     coeffl2norm = zeros(1, n_samples)
+    #    mtmp = zeros(output_dim,n_test)
+    #    vtmp = zeros(output_dim,output_dim,n_test)
+    ctmp = zeros(n_features)
+
     for i in 1:n_samples
         for j in 1:repeats
-            m, v, c, cplxty = calculate_mean_cov_and_coeffs(rng, l, lambda, n_features, batch_sizes, io_pairs)
+            ctmp[:], cplxtytmp = calculate_mean_cov_and_coeffs(
+                rng,
+                l,
+                lambda,
+                n_features,
+                batch_sizes,
+                io_pairs,
+                means[:, i, :],
+                covs[:, i, :, :],
+            )
             # m output_dim x n_test
             # v output_dim x output_dim x n_test
             # c n_features
-            means[:, i, :] += m' ./ repeats
-            covs[:, i, :, :] += permutedims(v, (3, 1, 2)) ./ repeats
-            coeffl2norm[1, i] += sqrt(sum(c .^ 2)) / repeats
-            complexity[1, i] += cplxty / repeats
+            #            means[:, i, :] += mtmp' ./ repeats
+            #            covs[:, i, :, :] += vtmp ./ repeats
+            coeffl2norm[1, i] += sqrt(sum(ctmp .^ 2)) / repeats
+            complexity[1, i] += cplxtytmp / repeats
 
         end
     end
+    means = permutedims(means, (3, 2, 1))
+    covs = permutedims(covs, (4, 2, 1, 3))
+
 
     blockcovmat = zeros(n_samples, n_test * output_dim, n_test * output_dim)
     blockmeans = zeros(n_test * output_dim, n_samples)
@@ -229,14 +270,19 @@ function estimate_mean_and_coeffnorm_covariance(
 end
 
 function calculate_ensemble_mean_and_coeffnorm(
-    rng::AbstractRNG,
-    lvecormat::AbstractVecOrMat,
-    lambda,
+    rng::RNG,
+    lvecormat::VorM,
+    lambda::L,
     n_features::Int,
-    batch_sizes::Dict,
+    batch_sizes::Dict{S, Int},
     io_pairs::PairedDataContainer;
     repeats::Int = 1,
-)
+) where {
+    RNG <: AbstractRNG,
+    S <: AbstractString,
+    VorM <: AbstractVecOrMat,
+    L <: Union{AbstractMatrix, UniformScaling, Real},
+}
     if isa(lvecormat, AbstractVector)
         lmat = reshape(lvecormat, 1, :)
     else
@@ -247,23 +293,44 @@ function calculate_ensemble_mean_and_coeffnorm(
     n_test = size(get_inputs(io_pairs), 2) - n_train
     output_dim = size(get_outputs(io_pairs), 1)
 
-    means = zeros(n_test, N_ens, output_dim)
-    covs = zeros(n_test, N_ens, output_dim, output_dim)
+    #    means = zeros(n_test, N_ens, output_dim)
+    #    covs = zeros(n_test, N_ens, output_dim, output_dim)
+    means = zeros(output_dim, N_ens, n_test)
+    covs = zeros(output_dim, N_ens, output_dim, n_test)
     complexity = zeros(1, N_ens)
     coeffl2norm = zeros(1, N_ens)
+    #    mtmp = zeros(output_dim,n_test)
+    #    vtmp = zeros(output_dim,output_dim,n_test)
+    ctmp = zeros(n_features)
+
+    rfm_store = []
+    ff_store = []
+
+
     for i in collect(1:N_ens)
         for j in collect(1:repeats)
             l = lmat[:, i]
-            m, v, c, cplxty = calculate_mean_cov_and_coeffs(rng, l, lambda, n_features, batch_sizes, io_pairs)
+            ctmp[:], cplxtytmp = calculate_mean_cov_and_coeffs(
+                rng,
+                l,
+                lambda,
+                n_features,
+                batch_sizes,
+                io_pairs,
+                means[:, i, :],
+                covs[:, i, :, :],
+            )
             # m output_dim x n_test
             # v output_dim x output_dim x n_test
             # c n_features
-            means[:, i, :] += m' ./ repeats
-            covs[:, i, :, :] += permutedims(v, (3, 1, 2)) ./ repeats
-            coeffl2norm[1, i] += sqrt(sum(c .^ 2)) / repeats
-            complexity[1, i] += cplxty / repeats
+            #            means[:, i, :] += mtmp' ./ repeats
+            #            covs[:, i, :, :] += vtmp ./ repeats
+            coeffl2norm[1, i] += sqrt(sum(ctmp .^ 2)) / repeats
+            complexity[1, i] += cplxtytmp / repeats
         end
     end
+    means = permutedims(means, (3, 2, 1)) # n_test x 
+    covs = permutedims(covs, (4, 2, 1, 3)) #n_test x N_ens x output_dim x output_dim
 
     blockcovmat = zeros(N_ens, n_test * output_dim, n_test * output_dim)
     blockmeans = zeros(n_test * output_dim, N_ens)
@@ -281,166 +348,88 @@ function calculate_ensemble_mean_and_coeffnorm(
     return vcat(blockmeans, coeffl2norm, complexity), blockcovmat
 end
 
-## Begin Script, define problem setting
-println("Begin script")
-date_of_run = Date(2022, 11, 10)
+@time begin
+    ## Begin Script, define problem setting
+    println("Begin script")
+    date_of_run = Date(2022, 11, 10)
 
-input_dim = 1
-output_dim = 3
-println("Number of input dimensions: ", input_dim)
-println("Number of output dimensions: ", output_dim)
+    input_dim = 1
+    output_dim = 3
+    println("Number of input dimensions: ", input_dim)
+    println("Number of output dimensions: ", output_dim)
 
-function ftest_1d_to_3d(x::AbstractMatrix)
-    out = zeros(3, size(x, 2))
-    out[1, :] = mapslices(column -> sin(norm([i * c for (i, c) in enumerate(column)])^2), x, dims = 1)
-    out[2, :] = mapslices(column -> exp(-0.1 * norm([i * c for (i, c) in enumerate(column)])^2), x, dims = 1)
-    out[3, :] = mapslices(
-        column ->
-            norm([i * c for (i, c) in enumerate(column)]) * sin(1 / norm([i * c for (i, c) in enumerate(column)])^2) -
-            1,
-        x,
-        dims = 1,
-    )
-    return out
-end
+    function ftest_1d_to_3d(x::M) where {M <: AbstractMatrix}
+        out = zeros(3, size(x, 2))
+        out[1, :] = mapslices(column -> sin(norm([i * c for (i, c) in enumerate(column)])^2), x, dims = 1)
+        out[2, :] = mapslices(column -> exp(-0.1 * norm([i * c for (i, c) in enumerate(column)])^2), x, dims = 1)
+        out[3, :] = mapslices(
+            column ->
+                norm([i * c for (i, c) in enumerate(column)]) * sin(1 / norm([i * c for (i, c) in enumerate(column)])^2) -
+                1,
+            x,
+            dims = 1,
+        )
+        return out
+    end
 
-#problem formulation
-n_data = 100
-x = rand(rng, MvNormal(zeros(input_dim), I), n_data)
+    #problem formulation
+    n_data = 100
+    x = rand(rng, MvNormal(zeros(input_dim), I), n_data)
 
-# diagonal noise
-cov_mat = Diagonal((5e-2)^2 * ones(output_dim))
-#cov_mat = (5e-2)^2*I
-# correlated noise
-#cov_mat = convert(Matrix,Tridiagonal((5e-3) * ones(2), (2e-2) * ones(3), (5e-3) * ones(2)))
+    # diagonal noise
+    cov_mat = Diagonal((5e-2)^2 * ones(output_dim))
+    #cov_mat = (5e-2)^2*I
+    # correlated noise
+    #cov_mat = convert(Matrix,Tridiagonal((5e-3) * ones(2), (2e-2) * ones(3), (5e-3) * ones(2)))
 
-noise_dist = MvNormal(zeros(output_dim), cov_mat)
-noise = rand(rng, noise_dist, n_data)
+    noise_dist = MvNormal(zeros(output_dim), cov_mat)
+    noise = rand(rng, noise_dist, n_data)
 
-# simple regularization
-lambda = exp((1 / output_dim) * sum(log.(eigvals(cov_mat)))) * I
-# more complex
-#lambda = cov_mat
-
-
-y = ftest_1d_to_3d(x) + noise
-io_pairs = PairedDataContainer(x, y)
-
-## Define Hyperpriors for EKP
-
-μ_l = 5.0
-σ_l = 5.0
-# prior for non radial problem
-n_l = Int(0.5 * input_dim * (input_dim + 1)) + Int(0.5 * output_dim * (output_dim + 1))
-n_l += (input_dim > 1 && output_dim > 1) ? 2 : 0
-
-prior_lengthscale = constrained_gaussian("lengthscale", μ_l, σ_l, 0.0, Inf, repeats = n_l)
-priors = prior_lengthscale
-println("number of hyperparameters to train: ", n_l)
-
-# estimate the noise from running many RFM sample costs at the mean values
-batch_sizes = Dict("train" => 0, "test" => 0, "feature" => 0)
-n_train = Int(floor(0.8 * n_data))
-n_test = n_data - n_train
-n_features_opt = Int(floor(2 * n_train))
-#n_features = Int(floor(2 * n_data))
-# RF will perform poorly when n_features is close to n_train
-@assert(!(n_features_opt == n_train)) #
+    # simple regularization
+    lambda = exp((1 / output_dim) * sum(log.(eigvals(cov_mat)))) * I
+    # more complex
+    #lambda = cov_mat
 
 
-repeats = 1
+    y = ftest_1d_to_3d(x) + noise
+    io_pairs = PairedDataContainer(x, y)
 
-CALC_TRUTH = true
+    ## Define Hyperpriors for EKP
 
-println("RHKS norm type: norm of coefficients")
+    μ_l = 5.0
+    σ_l = 5.0
+    # prior for non radial problem
+    n_l = Int(0.5 * input_dim * (input_dim + 1)) + Int(0.5 * output_dim * (output_dim + 1))
+    n_l += (input_dim > 1 && output_dim > 1) ? 2 : 0
 
-if CALC_TRUTH
-    sample_multiplier = 1
+    prior_lengthscale = constrained_gaussian("lengthscale", μ_l, σ_l, 0.0, Inf, repeats = n_l)
+    priors = prior_lengthscale
+    println("number of hyperparameters to train: ", n_l)
 
-    n_samples = (n_test * output_dim + 2) * sample_multiplier
-    println("Estimating output covariance with ", n_samples, " samples")
-    internal_Γ, approx_σ2 = estimate_mean_and_coeffnorm_covariance(
-        rng,
-        repeat([μ_l], n_l), # take mean values
-        lambda,
-        n_features_opt,
-        batch_sizes,
-        io_pairs,
-        n_samples,
-        repeats = repeats,
-    )
+    # estimate the noise from running many RFM sample costs at the mean values
+    batch_sizes = Dict("train" => 500, "test" => 500, "feature" => 500)
+    n_train = Int(floor(0.8 * n_data))
+    n_test = n_data - n_train
+    n_features_opt = Int(floor(2 * n_train))
+    #n_features = Int(floor(2 * n_data))
+    # RF will perform poorly when n_features is close to n_train
+    @assert(!(n_features_opt == n_train)) #
 
 
-    save("calculated_truth_cov.jld2", "internal_Γ", internal_Γ, "approx_σ2", approx_σ2)
-else
-    println("Loading truth covariance from file...")
-    internal_Γ = load("calculated_truth_cov.jld2")["internal_Γ"]
-    approx_σ2 = load("calculated_truth_cov.jld2")["approx_σ2"]
-end
+    repeats = 1
 
-Γ = internal_Γ
-Γ[1:(n_test * output_dim), 1:(n_test * output_dim)] += approx_σ2
-Γ[(n_test * output_dim + 1):end, (n_test * output_dim + 1):end] += I
-println(
-    "Estimated variance. Tr(cov) = ",
-    tr(Γ[1:(n_test * output_dim), 1:(n_test * output_dim)]),
-    " + ",
-    Γ[end - 1, end - 1],
-    " + ",
-    Γ[end, end],
-)
-println("is EKP noise positive definite? ", isposdef(Γ))
-#println("noise in observations: ", Γ)
-# Create EKI
-N_ens = 10 * input_dim
-N_iter = 10
-update_cov_step = Inf
+    CALC_TRUTH = true
 
-initial_params = construct_initial_ensemble(priors, N_ens; rng_seed = ekp_seed)
-params_init = transform_unconstrained_to_constrained(priors, initial_params)#[1, :]
-println("Prior gives parameters between: [$(minimum(params_init)),$(maximum(params_init))]")
+    println("RHKS norm type: norm of coefficients")
 
-if isa(lambda, Real)
-    min_complexity = n_features_opt * log(lambda)
-    data = vcat(reshape(y[:, (n_train + 1):end], :, 1), 0.0, min_complexity) #flatten data
-elseif isa(lambda, UniformScaling)
-    min_complexity = n_features_opt * log(lambda.λ)
-    data = vcat(reshape(y[:, (n_train + 1):end], :, 1), 0.0, min_complexity) #flatten data
-else
-    min_complexity = (n_features_opt / output_dim) * 2 * sum(log.(diag(cholesky(lambda).L)))
-    # TODO: SOLVE EVAL PROBLEM TO FIT WITH THIS DATA. the following is just a fudge to get reasonable scaling and not a global truth
-    min_complexity *= 1
+    if CALC_TRUTH
+        sample_multiplier = 1
 
-    data = vcat(reshape(y[:, (n_train + 1):end], :, 1), 0.0, min_complexity) #flatten data
-end
-println("min_complexity: ", min_complexity)
-
-ekiobj = [EKP.EnsembleKalmanProcess(initial_params, data[:], Γ, Inversion())]
-err = zeros(N_iter)
-println("Begin EKI iterations:")
-Δt = [1.0]
-
-for i in 1:N_iter
-
-    #get parameters:
-    lvec = transform_unconstrained_to_constrained(priors, get_u_final(ekiobj[1]))
-    g_ens, _ = calculate_ensemble_mean_and_coeffnorm(
-        rng,
-        lvec,
-        lambda,
-        n_features_opt,
-        batch_sizes,
-        io_pairs,
-        repeats = repeats,
-    )
-
-    if i % update_cov_step == 0 # to update cov if required
-
-        constrained_u = transform_unconstrained_to_constrained(priors, get_u_final(ekiobj[1]))
+        n_samples = (n_test * output_dim + 2) * sample_multiplier
         println("Estimating output covariance with ", n_samples, " samples")
-        internal_Γ_new, approx_σ2_new = estimate_mean_and_coeffnorm_covariance(
+        internal_Γ, approx_σ2 = estimate_mean_and_coeffnorm_covariance(
             rng,
-            mean(constrained_u, dims = 2)[:, 1], # take mean values
+            repeat([μ_l], n_l), # take mean values
             lambda,
             n_features_opt,
             batch_sizes,
@@ -448,136 +437,229 @@ for i in 1:N_iter
             n_samples,
             repeats = repeats,
         )
-        Γ_new = internal_Γ_new
-        Γ_new[1:(n_test * output_dim), 1:(n_test * output_dim)] += approx_σ2_new
-        Γ_new[(n_test * output_dim + 1):end, (n_test * output_dim + 1):end] += I
-        println(
-            "Estimated variance. Tr(cov) = ",
-            tr(Γ_new[1:n_test, 1:n_test]),
-            " + ",
-            tr(Γ_new[(n_test * output_dim + 1):end, (n_test * output_dim + 1):end]),
+        #=   @profview estimate_mean_and_coeffnorm_covariance(
+                rng,
+                repeat([μ_l], n_l), # take mean values
+                lambda,
+                n_features_opt,
+                batch_sizes,
+                io_pairs,
+                n_samples,
+                repeats = repeats,
+            )=#
+        save("calculated_truth_cov.jld2", "internal_Γ", internal_Γ, "approx_σ2", approx_σ2)
+    else
+        println("Loading truth covariance from file...")
+        internal_Γ = load("calculated_truth_cov.jld2")["internal_Γ"]
+        approx_σ2 = load("calculated_truth_cov.jld2")["approx_σ2"]
+    end
+
+    Γ = internal_Γ
+    Γ[1:(n_test * output_dim), 1:(n_test * output_dim)] += approx_σ2
+    Γ[(n_test * output_dim + 1):end, (n_test * output_dim + 1):end] += I
+    println(
+        "Estimated variance. Tr(cov) = ",
+        tr(Γ[1:(n_test * output_dim), 1:(n_test * output_dim)]),
+        " + ",
+        Γ[end - 1, end - 1],
+        " + ",
+        Γ[end, end],
+    )
+    println("is EKP noise positive definite? ", isposdef(Γ))
+    #println("noise in observations: ", Γ)
+    # Create EKI
+    N_ens = 10 * input_dim
+    N_iter = 10
+    update_cov_step = Inf
+
+    initial_params = construct_initial_ensemble(priors, N_ens; rng_seed = ekp_seed)
+    params_init = transform_unconstrained_to_constrained(priors, initial_params)#[1, :]
+    println("Prior gives parameters between: [$(minimum(params_init)),$(maximum(params_init))]")
+
+    if isa(lambda, Real)
+        min_complexity = n_features_opt * log(lambda)
+        data = vcat(reshape(y[:, (n_train + 1):end], :, 1), 0.0, min_complexity) #flatten data
+    elseif isa(lambda, UniformScaling)
+        min_complexity = n_features_opt * log(lambda.λ)
+        data = vcat(reshape(y[:, (n_train + 1):end], :, 1), 0.0, min_complexity) #flatten data
+    else
+        min_complexity = (n_features_opt / output_dim) * 2 * sum(log.(diag(cholesky(lambda).L)))
+        # TODO: SOLVE EVAL PROBLEM TO FIT WITH THIS DATA. the following is just a fudge to get reasonable scaling and not a global truth
+        min_complexity *= 1
+
+        data = vcat(reshape(y[:, (n_train + 1):end], :, 1), 0.0, min_complexity) #flatten data
+    end
+    println("min_complexity: ", min_complexity)
+
+    ekiobj = [EKP.EnsembleKalmanProcess(initial_params, data[:], Γ, Inversion())]
+    err = zeros(N_iter)
+    println("Begin EKI iterations:")
+    Δt = [1.0]
+
+    for i in 1:N_iter
+
+        #get parameters:
+        lvec = transform_unconstrained_to_constrained(priors, get_u_final(ekiobj[1]))
+        g_ens, _ = calculate_ensemble_mean_and_coeffnorm(
+            rng,
+            lvec,
+            lambda,
+            n_features_opt,
+            batch_sizes,
+            io_pairs,
+            repeats = repeats,
         )
 
-        ekiobj[1] = EKP.EnsembleKalmanProcess(get_u_final(ekiobj[1]), data[:], Γ_new, Inversion())
+        if i % update_cov_step == 0 # to update cov if required
+
+            constrained_u = transform_unconstrained_to_constrained(priors, get_u_final(ekiobj[1]))
+            println("Estimating output covariance with ", n_samples, " samples")
+            internal_Γ_new, approx_σ2_new = estimate_mean_and_coeffnorm_covariance(
+                rng,
+                mean(constrained_u, dims = 2)[:, 1], # take mean values
+                lambda,
+                n_features_opt,
+                batch_sizes,
+                io_pairs,
+                n_samples,
+                repeats = repeats,
+            )
+            Γ_new = internal_Γ_new
+            Γ_new[1:(n_test * output_dim), 1:(n_test * output_dim)] += approx_σ2_new
+            Γ_new[(n_test * output_dim + 1):end, (n_test * output_dim + 1):end] += I
+            println(
+                "Estimated variance. Tr(cov) = ",
+                tr(Γ_new[1:n_test, 1:n_test]),
+                " + ",
+                tr(Γ_new[(n_test * output_dim + 1):end, (n_test * output_dim + 1):end]),
+            )
+
+            ekiobj[1] = EKP.EnsembleKalmanProcess(get_u_final(ekiobj[1]), data[:], Γ_new, Inversion())
+
+        end
+
+
+        EKP.update_ensemble!(ekiobj[1], g_ens, Δt_new = Δt[1])
+        err[i] = get_error(ekiobj[1])[end] #mean((params_true - mean(params_i,dims=2)).^2)
+        constrained_u = transform_unconstrained_to_constrained(priors, get_u_final(ekiobj[1]))
+        println(
+            "Iteration: " *
+            string(i) *
+            ", Error: " *
+            string(err[i]) *
+            ", for parameter means: \n" *
+            string(mean(constrained_u, dims = 2)),
+            "\n and sd :\n" * string(sqrt.(var(constrained_u, dims = 2))),
+        )
+        Δt[1] *= 1.0
 
     end
 
-    EKP.update_ensemble!(ekiobj[1], g_ens, Δt_new = Δt[1])
-    err[i] = get_error(ekiobj[1])[end] #mean((params_true - mean(params_i,dims=2)).^2)
-    constrained_u = transform_unconstrained_to_constrained(priors, get_u_final(ekiobj[1]))
-    println(
-        "Iteration: " *
-        string(i) *
-        ", Error: " *
-        string(err[i]) *
-        ", for parameter means: \n" *
-        string(mean(constrained_u, dims = 2)),
-        "\n and sd :\n" * string(sqrt.(var(constrained_u, dims = 2))),
-    )
-    Δt[1] *= 1.0
-end
-
-#run actual experiment
-# override following parameters for actual run
-n_data_test = 100 * input_dim
-n_features_test = Int(floor(2 * n_data_test))
-println("number of training data: ", n_data_test)
-println("number of features: ", n_features_test)
-x_test = rand(rng, MvNormal(zeros(input_dim), 0.5 * I), n_data_test)
-noise_test = rand(rng, noise_dist, n_data_test)
-
-y_test = ftest_1d_to_3d(x_test) + noise_test
-io_pairs_test = PairedDataContainer(x_test, y_test)
-
-# get feature distribution
-final_lvec = get_ϕ_mean_final(priors, ekiobj[1])
-println("**********")
-println("Optimal lengthscales: $(final_lvec)")
-println("**********")
 
 
-rfm = RFM_from_hyperparameters(rng, final_lvec, lambda, n_features_test, batch_sizes, input_dim, output_dim)
-fitted_features = fit(rfm, io_pairs_test, decomposition_type = "cholesky")
+    #run actual experiment
+    # override following parameters for actual run
+    n_data_test = 100 * input_dim
+    n_features_test = Int(floor(2 * n_data_test))
+    println("number of training data: ", n_data_test)
+    println("number of features: ", n_features_test)
+    x_test = rand(rng, MvNormal(zeros(input_dim), 0.5 * I), n_data_test)
+    noise_test = rand(rng, noise_dist, n_data_test)
 
-if PLOT_FLAG
-    # learning on Normal(0,1) dist, forecast on (-2,2)
-    xrange = reshape(collect(-2.01:0.02:2.01), 1, :)
+    y_test = ftest_1d_to_3d(x_test) + noise_test
+    io_pairs_test = PairedDataContainer(x_test, y_test)
 
-    yrange = ftest_1d_to_3d(xrange)
+    # get feature distribution
+    final_lvec = get_ϕ_mean_final(priors, ekiobj[1])
+    println("**********")
+    println("Optimal lengthscales: $(final_lvec)")
+    println("**********")
 
-    pred_mean_slice, pred_cov_slice = predict(rfm, fitted_features, DataContainer(xrange))
 
-    for i in 1:output_dim
-        pred_cov_slice[i, i, :] = max.(pred_cov_slice[i, i, :], 0.0)
+    rfm = RFM_from_hyperparameters(rng, final_lvec, lambda, n_features_test, batch_sizes, input_dim, output_dim)
+    fitted_features = fit(rfm, io_pairs_test, decomposition_type = "cholesky")
+
+    if PLOT_FLAG
+        # learning on Normal(0,1) dist, forecast on (-2,2)
+        xrange = reshape(collect(-2.01:0.02:2.01), 1, :)
+
+        yrange = ftest_1d_to_3d(xrange)
+
+        pred_mean_slice, pred_cov_slice = predict(rfm, fitted_features, DataContainer(xrange))
+
+        for i in 1:output_dim
+            pred_cov_slice[i, i, :] = max.(pred_cov_slice[i, i, :], 0.0)
+        end
+
+        figure_save_directory = joinpath(@__DIR__, "output", string(date_of_run))
+        if !isdir(figure_save_directory)
+            mkpath(figure_save_directory)
+        end
+
+        #plot diagonal
+
+        xplot = xrange[:]
+        plt = plot(
+            xplot,
+            yrange[1, :],
+            show = false,
+            color = "black",
+            linewidth = 5,
+            size = (600, 600),
+            legend = :topleft,
+            label = "Target",
+        )
+        plot!(
+            xplot,
+            yrange[2, :],
+            show = false,
+            color = "black",
+            linewidth = 5,
+            size = (600, 600),
+            legend = :topleft,
+            label = "Target",
+        )
+        plot!(
+            xplot,
+            yrange[3, :],
+            show = false,
+            color = "black",
+            linewidth = 5,
+            size = (600, 600),
+            legend = :topleft,
+            label = "Target",
+        )
+        scatter!(x_test[:], y_test[1, :], color = "blue", label = "", marker = :x)
+
+        plot!(
+            xplot,
+            pred_mean_slice[1, :],
+            ribbon = [2 * sqrt.(pred_cov_slice[1, 1, :]); 2 * sqrt.(pred_cov_slice[1, 1, :])],
+            label = "Fourier",
+            color = "blue",
+        )
+        scatter!(x_test[:], y_test[2, :], color = "red", label = "", marker = :x)
+        plot!(
+            xplot,
+            pred_mean_slice[2, :],
+            ribbon = [2 * sqrt.(pred_cov_slice[2, 2, :]); 2 * sqrt.(pred_cov_slice[2, 2, :])],
+            label = "Fourier",
+            color = "red",
+        )
+        scatter!(x_test[:], y_test[3, :], color = "green", label = "", marker = :x)
+        plot!(
+            xplot,
+            pred_mean_slice[3, :],
+            ribbon = [2 * sqrt.(pred_cov_slice[3, 3, :]); 2 * sqrt.(pred_cov_slice[3, 3, :])],
+            label = "Fourier",
+            color = "green",
+        )
+
+        savefig(plt, joinpath(figure_save_directory, "Fit_and_predict_1D_to_MD.pdf"))
+        savefig(plt, joinpath(figure_save_directory, "Fit_and_predict_1D_to_MD.png"))
+
+
+
     end
-
-    figure_save_directory = joinpath(@__DIR__, "output", string(date_of_run))
-    if !isdir(figure_save_directory)
-        mkpath(figure_save_directory)
-    end
-
-    #plot diagonal
-
-    xplot = xrange[:]
-    plt = plot(
-        xplot,
-        yrange[1, :],
-        show = false,
-        color = "black",
-        linewidth = 5,
-        size = (600, 600),
-        legend = :topleft,
-        label = "Target",
-    )
-    plot!(
-        xplot,
-        yrange[2, :],
-        show = false,
-        color = "black",
-        linewidth = 5,
-        size = (600, 600),
-        legend = :topleft,
-        label = "Target",
-    )
-    plot!(
-        xplot,
-        yrange[3, :],
-        show = false,
-        color = "black",
-        linewidth = 5,
-        size = (600, 600),
-        legend = :topleft,
-        label = "Target",
-    )
-    scatter!(x_test[:], y_test[1, :], color = "blue", label = "", marker = :x)
-
-    plot!(
-        xplot,
-        pred_mean_slice[1, :],
-        ribbon = [2 * sqrt.(pred_cov_slice[1, 1, :]); 2 * sqrt.(pred_cov_slice[1, 1, :])],
-        label = "Fourier",
-        color = "blue",
-    )
-    scatter!(x_test[:], y_test[2, :], color = "red", label = "", marker = :x)
-    plot!(
-        xplot,
-        pred_mean_slice[2, :],
-        ribbon = [2 * sqrt.(pred_cov_slice[2, 2, :]); 2 * sqrt.(pred_cov_slice[2, 2, :])],
-        label = "Fourier",
-        color = "red",
-    )
-    scatter!(x_test[:], y_test[3, :], color = "green", label = "", marker = :x)
-    plot!(
-        xplot,
-        pred_mean_slice[3, :],
-        ribbon = [2 * sqrt.(pred_cov_slice[3, 3, :]); 2 * sqrt.(pred_cov_slice[3, 3, :])],
-        label = "Fourier",
-        color = "green",
-    )
-
-    savefig(plt, joinpath(figure_save_directory, "Fit_and_predict_1D_to_MD.pdf"))
-    savefig(plt, joinpath(figure_save_directory, "Fit_and_predict_1D_to_MD.png"))
-
-
 
 end

--- a/src/Features.jl
+++ b/src/Features.jl
@@ -20,7 +20,7 @@ $(TYPEDSIGNATURES)
 
 samples the random feature distribution 
 """
-function sample(rf::RandomFeature)
+function sample(rf::RF) where {RF <: RandomFeature}
     sampler = get_feature_sampler(rf)
     m = get_n_features(rf)
     return sample(sampler, m)
@@ -32,35 +32,35 @@ $(TYPEDSIGNATURES)
 
 gets the `n_features` field 
 """
-get_n_features(rf::RandomFeature) = rf.n_features
+get_n_features(rf::RF) where {RF <: RandomFeature} = rf.n_features
 
 """
 $(TYPEDSIGNATURES)
 
 gets the `scalar_function` field 
 """
-get_scalar_function(rf::RandomFeature) = rf.scalar_function
+get_scalar_function(rf::RF) where {RF <: RandomFeature} = rf.scalar_function
 
 """
 $(TYPEDSIGNATURES)
 
 gets the `feature_sampler` field 
 """
-get_feature_sampler(rf::RandomFeature) = rf.feature_sampler
+get_feature_sampler(rf::RF) where {RF <: RandomFeature} = rf.feature_sampler
 
 """
 $(TYPEDSIGNATURES)
 
 gets the `feature_sample` field 
 """
-get_feature_sample(rf::RandomFeature) = rf.feature_sample
+get_feature_sample(rf::RF) where {RF <: RandomFeature} = rf.feature_sample
 
 """
 $(TYPEDSIGNATURES)
 
 gets the `feature_parameters` field 
 """
-get_feature_parameters(rf::RandomFeature) = rf.feature_parameters
+get_feature_parameters(rf::RF) where {RF <: RandomFeature} = rf.feature_parameters
 
 
 

--- a/src/Methods.jl
+++ b/src/Methods.jl
@@ -1,6 +1,6 @@
 module Methods
 
-import StatsBase: sample, fit, predict
+import StatsBase: sample, fit, predict, predict!
 
 using LinearAlgebra,
     DocStringExtensions,
@@ -20,8 +20,11 @@ export RandomFeatureMethod,
     get_coeffs,
     fit,
     predict,
+    predict!,
     predictive_mean,
     predictive_cov,
+    predictive_mean!,
+    predictive_cov!,
     predict_prior,
     predict_prior_mean,
     predict_prior_cov
@@ -33,13 +36,13 @@ Holds configuration for the random feature fit
 
 $(TYPEDFIELDS)
 """
-struct RandomFeatureMethod
+struct RandomFeatureMethod{S <: AbstractString, USorM <: Union{UniformScaling, AbstractMatrix}}
     "The random feature object"
     random_feature::RandomFeature
     "A dictionary specifying the batch sizes. Must contain \"train\", \"test\", and \"feature\" keys"
-    batch_sizes::Dict
+    batch_sizes::Dict{S, Int}
     "A positive definite matrix used during the fit method to regularize the linear solve"
-    regularization::Union{UniformScaling, AbstractMatrix}
+    regularization::USorM
 end
 
 """
@@ -49,9 +52,9 @@ Basic constructor for a `RandomFeatureMethod`.
 """
 function RandomFeatureMethod(
     random_feature::RandomFeature;
-    regularization::Union{Real, AbstractMatrix, UniformScaling} = 1e12 * eps() * I,
-    batch_sizes::Dict = Dict{AbstractString, Int}("train" => 0, "test" => 0, "feature" => 0),
-)
+    regularization::USorMorR = 1e12 * eps() * I,
+    batch_sizes::Dict{S, Int} = Dict("train" => 0, "test" => 0, "feature" => 0),
+) where {S <: AbstractString, USorMorR <: Union{Real, AbstractMatrix, UniformScaling}}
 
     if !all([key ∈ keys(batch_sizes) for key in ["train", "test", "feature"]])
         throw(ArgumentError("batch_sizes keys must contain all of \"train\", \"test\", and \"feature\""))
@@ -74,7 +77,7 @@ function RandomFeatureMethod(
         end
     end
 
-    return RandomFeatureMethod(random_feature, batch_sizes, lambda)
+    return RandomFeatureMethod{S, typeof(lambda)}(random_feature, batch_sizes, lambda)
 end
 
 """
@@ -112,7 +115,7 @@ $(TYPEDSIGNATURES)
 
 get the specified batch size from `batch_sizes` field
 """
-get_batch_size(rfm::RandomFeatureMethod, key::AbstractString) = get_batch_sizes(rfm)[key]
+get_batch_size(rfm::RandomFeatureMethod, key::S) where {S <: AbstractString} = get_batch_sizes(rfm)[key]
 
 
 """
@@ -122,13 +125,13 @@ Holds the coefficients and matrix decomposition that describe a set of fitted ra
 
 $(TYPEDFIELDS)
 """
-struct Fit
+struct Fit{V <: AbstractVector, USorM <: Union{UniformScaling, AbstractMatrix}}
     "The `LinearAlgreba` matrix decomposition of `(1 / m) * Feature^T * Feature + regularization`"
     feature_factors::Decomposition
     "Coefficients of the fit to data"
-    coeffs::AbstractVector
+    coeffs::V
     "feature-space regularization used during fit"
-    regularization::Union{UniformScaling, AbstractMatrix}
+    regularization::USorM
 end
 
 """
@@ -163,8 +166,8 @@ Returns a `Fit` object.
 function fit(
     rfm::RandomFeatureMethod,
     input_output_pairs::PairedDataContainer;
-    decomposition_type::AbstractString = "svd",
-)
+    decomposition_type::S = "svd",
+) where {S <: AbstractString}
 
     (input, output) = get_data(input_output_pairs)
     input_dim, n_data = size(input)
@@ -222,13 +225,25 @@ function fit(
 
     PhiTY = zeros(n_features) #
     PhiTPhi = zeros(n_features, n_features)
+
     for (ib, ob) in zip(batch_input, batch_output)
         batch_feature = build_features(rf, ib) # batch_size x output_dim x n_features  
         @tullio PhiTY[j] += batch_feature[n, p, j] * ob[p, n]
-        @tullio PhiTPhi[i, j] += batch_feature[n, p, i] * batch_feature[n, p, j]
-
+        @tullio PhiTPhi[i, j] += batch_feature[n, p, i] * batch_feature[n, p, j] # BOTTLENECK OF SOLVER
     end
-    PhiTPhi ./= n_features
+
+    # alternative using svd - turns out to be slower and more mem intensive
+    #=
+    Phi = build_features(rf, input) # n_data x output_dim x n_features
+    @tullio PhiTY[j] = Phi[n, p, j] * output[p, n]
+    tmpPhi = zeros(size(Phi,1) * size(Phi,2),size(Phi,3))
+    P = svd(@cast tmpPhi[(j,i),k] = Phi[i,j,k])
+    out = similar(P.V)
+    PhiTPhi = similar(out)
+    mul!(PhiTPhi, mul!(out, P.V, Diagonal(P.S .^2)), P.Vt)
+    =#
+
+    @. PhiTPhi /= n_features
     PhiTY = reshape(PhiTY, n_features, 1, 1) # RHS kept as a 3-array (n_features x n_samples x dim_output)
 
     # solve the linear system
@@ -237,11 +252,20 @@ function fit(
     if lambda_new == 0 * I
         feature_factors = Decomposition(PhiTPhi, "pinv")
     else
-        feature_factors = Decomposition(PhiTPhi + lambda_new, decomposition_type)
+        # in-place add lambda (as we don't use PhiTPhi again after this)
+        if isa(lambda_new, UniformScaling)
+            # much quicker than just adding lambda_new...
+            for i in 1:size(PhiTPhi, 1)
+                PhiTPhi[i, i] += lambda_new.λ
+            end
+        else
+            @. PhiTPhi += lambda_new
+        end
+        feature_factors = Decomposition(PhiTPhi, decomposition_type)
     end
     coeffs = linear_solve(feature_factors, PhiTY) #n_features x n_samples x dim_output
 
-    return Fit(feature_factors, coeffs[:], lambda_new)
+    return Fit{typeof(coeffs[:]), typeof(lambda_new)}(feature_factors, coeffs[:], lambda_new)
 end
 
 
@@ -254,6 +278,24 @@ function predict(rfm::RandomFeatureMethod, fit::Fit, new_inputs::DataContainer)
     pred_mean = predictive_mean(rfm, fit, new_inputs)
     pred_cov, _ = predictive_cov(rfm, fit, new_inputs)
     return pred_mean, pred_cov
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Makes a prediction of mean and (co)variance of fitted features on new input data, overwriting the provided stores
+"""
+function predict!(
+    rfm::RandomFeatureMethod,
+    fit::Fit,
+    new_inputs::DataContainer,
+    mean_store::Matrix{R},
+    cov_store::Array{R, 3},
+) where {R <: Real}
+
+    predictive_mean!(rfm, fit, new_inputs, mean_store)
+    predictive_cov!(rfm, fit, new_inputs, cov_store)
+    nothing
 end
 
 
@@ -306,8 +348,8 @@ function predict_prior_cov(rfm::RandomFeatureMethod, new_inputs::DataContainer)
         # bsize x n_features
         @tullio ob[p, q, n] += features[n, p, m] * features[l, q, m] - features[l, q, m]
     end
-    cov_outputs ./= n_features
 
+    @. cov_outputs /= n_features
     return cov_outputs
 end
 
@@ -319,7 +361,14 @@ Makes a prediction of mean of fitted features on new input data
 predictive_mean(rfm::RandomFeatureMethod, fit::Fit, new_inputs::DataContainer) =
     predictive_mean(rfm, get_coeffs(fit), new_inputs)
 
-function predictive_mean(rfm::RandomFeatureMethod, coeffs::AbstractVector, new_inputs::DataContainer)
+predictive_mean!(
+    rfm::RandomFeatureMethod,
+    fit::Fit,
+    new_inputs::DataContainer,
+    mean_store::Matrix{R},
+) where {R <: Real} = predictive_mean!(rfm, get_coeffs(fit), new_inputs, mean_store)
+
+function predictive_mean(rfm::RandomFeatureMethod, coeffs::V, new_inputs::DataContainer) where {V <: AbstractVector}
 
     inputs = get_data(new_inputs)
 
@@ -338,15 +387,59 @@ function predictive_mean(rfm::RandomFeatureMethod, coeffs::AbstractVector, new_i
 
     for (ib, ob) in zip(batch_inputs, batch_outputs)
         for (cb, fb_i) in zip(batch_coeffs, batch_feature_idx)
-            features = build_features(rf, ib, fb_i) # n_samples x output_dim x n_features
+            # features = build_features(rf, ib, fb_i) # n_samples x output_dim x n_features
             #Dot very important...
             #ob .+= permutedims(features * reshape(cb, :, 1) / n_features, (2, 1)) # 1 x n_samples
-            @tullio ob[p, n] += features[n, p, m] * cb[m]
+            @tullio ob[p, n] += build_features(rf, ib, fb_i)[n, p, m] * cb[m]
         end
     end
-    outputs ./= n_features
+    @. outputs /= n_features
 
     return outputs
+end
+
+function predictive_mean!(
+    rfm::RandomFeatureMethod,
+    coeffs::V,
+    new_inputs::DataContainer,
+    mean_store::Matrix{R},
+) where {R <: Real, V <: AbstractVector}
+
+    inputs = get_data(new_inputs)
+
+    test_batch_size = get_batch_size(rfm, "test")
+    features_batch_size = get_batch_size(rfm, "feature")
+    rf = get_random_feature(rfm)
+    output_dim = get_output_dim(rf)
+    if !(size(mean_store) == (output_dim, size(inputs, 2)))
+        throw(
+            DimensionMismatch(
+                "provided storage for output expected to be size ($(output_dim),$(size(inputs,2))) got $(size(mean_store))",
+            ),
+        )
+    end
+
+
+    n_features = get_n_features(rf)
+
+    batch_inputs = batch_generator(inputs, test_batch_size, dims = 2) # input_dim x batch_size
+    batch_outputs = batch_generator(mean_store, test_batch_size, dims = 2) # input_dim x batch_size
+    batch_coeffs = batch_generator(coeffs, features_batch_size) # batch_size
+    batch_feature_idx = batch_generator(collect(1:n_features), features_batch_size) # batch_size
+    for (ib, ob) in zip(batch_inputs, batch_outputs)
+        for (idx_in, cb, fb_i) in zip(1:length(batch_coeffs), batch_coeffs, batch_feature_idx)
+            #features = build_features(rf, ib, fb_i) # n_samples x output_dim x n_features
+            #Dot very important...
+            #ob .+= permutedims(features * reshape(cb, :, 1) / n_features, (2, 1)) # 1 x n_samples
+            if idx_in == 1
+                @tullio ob[p, n] = build_features(rf, ib, fb_i)[n, p, m] * cb[m]
+            else
+                @tullio ob[p, n] += build_features(rf, ib, fb_i)[n, p, m] * cb[m]
+            end
+        end
+    end
+    @. mean_store /= n_features
+    nothing
 end
 
 """
@@ -364,16 +457,14 @@ function predictive_cov(rfm::RandomFeatureMethod, fit::Fit, new_inputs::DataCont
     test_batch_size = get_batch_size(rfm, "test")
     features_batch_size = get_batch_size(rfm, "feature")
     rf = get_random_feature(rfm)
+    n_features = get_n_features(rf)
     lambda = get_regularization(fit)
 
-    n_features = get_n_features(rf)
-
+    output_dim = get_output_dim(rf)
     coeffs = get_coeffs(fit)
     PhiTPhi_reg_factors = get_feature_factors(fit)
     PhiTPhi_reg = get_full_matrix(PhiTPhi_reg_factors)
-    PhiTPhi = PhiTPhi_reg - lambda
 
-    output_dim = get_output_dim(rf)
     cov_outputs = zeros(output_dim, output_dim, size(inputs, 2))
     coeff_outputs = zeros(n_features, size(inputs, 2), output_dim)
 
@@ -381,22 +472,102 @@ function predictive_cov(rfm::RandomFeatureMethod, fit::Fit, new_inputs::DataCont
     batch_outputs = batch_generator(cov_outputs, test_batch_size, dims = 3) # 1 x batch_size
     batch_coeff_outputs = batch_generator(coeff_outputs, test_batch_size, dims = 2)
 
-    for (ib, ob, cob) in zip(batch_inputs, batch_outputs, batch_coeff_outputs)
-        features = build_features(rf, ib) # bsize x output_dim x n_features  
-        #rhs = PhiTPhi * permutedims(features, (2, 1)) # = 1/m * phi(X)^T * phi(X) * phi(x')^T = phi(X)^T * k(X,x')
-        @tullio rhs[i, n, p] := PhiTPhi[i, j] * features[n, p, j]
-        c_tmp = linear_solve(PhiTPhi_reg_factors, rhs) # n_features x bsize x output_dim
-        #Dot very important
-        @tullio cob[i, n, p] += c_tmp[i, n, p]
-        # here we do a pointwise calculation of var (1d output) for each test point
-        #        ob .+= sum(permutedims(features, (2, 1)) .* (permutedims(features, (2, 1)) - c_tmp), dims = 1) / n_features
-        @tullio ob[p, q, n] += features[n, p, m] * (features[n, q, m] - c_tmp[m, n, q])
+    if isa(lambda, UniformScaling)
+        for (ib, ob, cob) in zip(batch_inputs, batch_outputs, batch_coeff_outputs)
+            features = build_features(rf, ib) # bsize x output_dim x n_features  
+            # "rhs[i, n, p] := features[n, p, i]"
+            c_tmp = linear_solve(PhiTPhi_reg_factors, permutedims(features, (3, 1, 2))) # n_features x bsize x output_dim
+            #Dot very important
+            @tullio cob[i, n, p] += c_tmp[i, n, p]
+            # here we do a pointwise calculation of var (1d output) for each test point
+            #        ob .+= sum(permutedims(features, (2, 1)) .* (permutedims(features, (2, 1)) - c_tmp), dims = 1) / n_features
+            @tullio ob[p, q, n] += features[n, p, m] * c_tmp[m, n, q]
+        end
+        @. cov_outputs /= (n_features / lambda.λ)
 
+    else
+        for (ib, ob, cob) in zip(batch_inputs, batch_outputs, batch_coeff_outputs)
+            features = build_features(rf, ib) # bsize x output_dim x n_features  
+            #rhs = PhiTPhi * permutedims(features, (2, 1)) # = 1/m * phi(X)^T * phi(X) * phi(x')^T = phi(X)^T * k(X,x')
+            @tullio rhs[i, n, p] := (PhiTPhi_reg[i, j] - lambda[i, j]) * features[n, p, j] # BOTTLENECK OF PREDICTION
+            c_tmp = linear_solve(PhiTPhi_reg_factors, rhs) # n_features x bsize x output_dim
+            #Dot very important
+            @tullio cob[i, n, p] += c_tmp[i, n, p]
+            # here we do a pointwise calculation of var (1d output) for each test point
+            #        ob .+= sum(permutedims(features, (2, 1)) .* (permutedims(features, (2, 1)) - c_tmp), dims = 1) / n_features
+            @tullio ob[p, q, n] += features[n, p, m] * (features[n, q, m] - c_tmp[m, n, q])
+
+        end
+        @. cov_outputs /= n_features
     end
-    cov_outputs ./= n_features
 
     return cov_outputs, coeff_outputs
 end
+
+function predictive_cov!(
+    rfm::RandomFeatureMethod,
+    fit::Fit,
+    new_inputs::DataContainer,
+    cov_store::Array{R, 3},
+) where {R <: Real}
+
+    # unlike in mean case, we must perform a linear solve for coefficients at every test point.
+    # thus we return both the covariance and the input-dep coefficients
+    # note the covariance here is a posterior variance in 1d outputs, it is not the posterior covariance
+
+    inputs = get_data(new_inputs)
+
+    test_batch_size = get_batch_size(rfm, "test")
+    features_batch_size = get_batch_size(rfm, "feature")
+    rf = get_random_feature(rfm)
+    n_features = get_n_features(rf)
+    lambda = get_regularization(fit)
+
+    output_dim = get_output_dim(rf)
+    coeffs = get_coeffs(fit)
+    PhiTPhi_reg_factors = get_feature_factors(fit)
+    PhiTPhi_reg = get_full_matrix(PhiTPhi_reg_factors)
+
+    if !(size(cov_store) == (output_dim, output_dim, size(inputs, 2)))
+        throw(
+            DimensionMismatch(
+                "provided storage for output expected to be size ($(output_dim),$(output_dim),$(size(inputs,2))) got $(size(cov_store))",
+            ),
+        )
+    end
+
+    #    cov_outputs = zeros(output_dim, output_dim, size(inputs, 2))
+
+    batch_inputs = batch_generator(inputs, test_batch_size, dims = 2) # input_dim x batch_size
+    batch_outputs = batch_generator(cov_store, test_batch_size, dims = 3) # 1 x batch_size
+
+    if isa(lambda, UniformScaling)
+        for (ib, ob) in zip(batch_inputs, batch_outputs)
+            features = build_features(rf, ib) # bsize x output_dim x n_features  
+            @tullio rhs[i, n, p] := features[n, p, i]
+            c_tmp = linear_solve(PhiTPhi_reg_factors, rhs)#permutedims(features, (3,1,2))) # n_features x bsize x output_dim
+            # here we do a pointwise calculation of var (1d output) for each test point
+            #        ob .+= sum(permutedims(features, (2, 1)) .* (permutedims(features, (2, 1)) - c_tmp), dims = 1) / n_features
+            @tullio ob[p, q, n] = features[n, p, m] * c_tmp[m, n, q]
+        end
+        @. cov_store /= (n_features / lambda.λ) #i.e. * lambda / n_features
+    else
+
+        for (ib, ob) in zip(batch_inputs, batch_outputs)
+            features = build_features(rf, ib) # bsize x output_dim x n_features  
+            #rhs = PhiTPhi * permutedims(features, (2, 1)) # = 1/m * phi(X)^T * phi(X) * phi(x')^T = phi(X)^T * k(X,x')
+            @tullio rhs[i, n, p] := (PhiTPhi_reg[i, j] - lambda[i, j]) * features[n, p, j] # BOTTLENECK OF PREDICTION
+            c_tmp = linear_solve(PhiTPhi_reg_factors, rhs) # n_features x bsize x output_dim
+            # here we do a pointwise calculation of var (1d output) for each test point
+            #        ob .+= sum(permutedims(features, (2, 1)) .* (permutedims(features, (2, 1)) - c_tmp), dims = 1) / n_features
+            @tullio ob[p, q, n] = features[n, p, m] * (features[n, q, m] - c_tmp[m, n, q])
+
+        end
+        @. cov_store /= n_features
+    end
+    nothing
+end
+
 
 # TODO
 # function posterior_cov(rfm::RandomFeatureMethod, u_input, v_input)

--- a/src/ScalarFunctions.jl
+++ b/src/ScalarFunctions.jl
@@ -36,13 +36,14 @@ $(TYPEDSIGNATURES)
 
 apply the scalar function `sf` pointwise to vectors or matrices
 """
-apply_scalar_function(sf::ScalarFunction, r::AbstractArray) = apply_scalar_function.(Ref(sf), r) # Ref(sf) treats sf as a scalar for the broadcasting
+apply_scalar_function(sf::SF, r::A) where {SF <: ScalarFunction, A <: AbstractArray} =
+    apply_scalar_function.(Ref(sf), r) # Ref(sf) treats sf as a scalar for the broadcasting
 
 """
 $(TYPEDEF)
 """
 struct Cosine <: ScalarFunction end
-function apply_scalar_function(sf::Cosine, r::Real)
+function apply_scalar_function(sf::Cosine, r::FT) where {FT <: AbstractFloat}
     return cos(r)
 end
 
@@ -58,7 +59,7 @@ abstract type ScalarActivation <: ScalarFunction end
 $(TYPEDEF)
 """
 struct Relu <: ScalarActivation end
-function apply_scalar_function(sa::Relu, r::Real)
+function apply_scalar_function(sa::Relu, r::FT) where {FT <: AbstractFloat}
     return max(0, r)
 end
 
@@ -66,7 +67,7 @@ end
 $(TYPEDEF)
 """
 struct Gelu <: ScalarActivation end
-function apply_scalar_function(sa::Gelu, r::Real)
+function apply_scalar_function(sa::Gelu, r::FT) where {FT <: AbstractFloat}
     cdf = 0.5 * (1.0 + erf(r / sqrt(2.0)))
     return r * cdf
 end
@@ -85,7 +86,7 @@ function heaviside(x, y)
     end
 end
 
-function apply_scalar_function(sa::Heaviside, r::Real)
+function apply_scalar_function(sa::Heaviside, r::FT) where {FT <: AbstractFloat}
     return heaviside(r, 0.5)
 end
 
@@ -93,7 +94,7 @@ end
 $(TYPEDEF)
 """
 struct Sawtooth <: ScalarActivation end
-function apply_scalar_function(sa::Sawtooth, r::Real)
+function apply_scalar_function(sa::Sawtooth, r::FT) where {FT <: AbstractFloat}
     return max(0, min(2 * r, 2 - 2 * r))
 end
 
@@ -101,7 +102,7 @@ end
 $(TYPEDEF)
 """
 struct Softplus <: ScalarActivation end
-function apply_scalar_function(sa::Softplus, r::Real)
+function apply_scalar_function(sa::Softplus, r::FT) where {FT <: AbstractFloat}
     return log(1 + exp(-abs(r))) + max(r, 0)
 end
 
@@ -109,7 +110,7 @@ end
 $(TYPEDEF)
 """
 struct Tansig <: ScalarActivation end
-function apply_scalar_function(sa::Tansig, r::Real)
+function apply_scalar_function(sa::Tansig, r::FT) where {FT <: AbstractFloat}
     return tanh(r)
 end
 
@@ -117,47 +118,47 @@ end
 $(TYPEDEF)
 """
 struct Sigmoid <: ScalarActivation end
-function apply_scalar_function(sa::Sigmoid, r::Real)
+function apply_scalar_function(sa::Sigmoid, r::FT) where {FT <: AbstractFloat}
     return 1 / (1 + exp(-r))
 end
 
 """
 $(TYPEDEF)
 """
-@kwdef struct Elu <: ScalarActivation
-    alpha::Real = 1.0
+@kwdef struct Elu{FT <: AbstractFloat} <: ScalarActivation
+    alpha::FT = 1.0
 end
-function apply_scalar_function(sa::Elu, r::Real)
+function apply_scalar_function(sa::Elu, r::FT) where {FT <: AbstractFloat}
     return r > 0 ? r : sa.alpha * (exp(r) - 1.0)
 end
 
 """
 $(TYPEDEF)
 """
-@kwdef struct Lrelu <: ScalarActivation
-    alpha::Real = 0.01
+@kwdef struct Lrelu{FT <: AbstractFloat} <: ScalarActivation
+    alpha::FT = 0.01
 end
-function apply_scalar_function(sa::Lrelu, r::Real)
+function apply_scalar_function(sa::Lrelu, r::FT) where {FT <: AbstractFloat}
     return r > 0 ? r : sa.alpha * r
 end
 
 """
 $(TYPEDEF)
 """
-@kwdef struct Selu <: ScalarActivation
-    alpha::Real = 1.67326
-    lambda::Real = 1.0507
+@kwdef struct Selu{FT <: AbstractFloat} <: ScalarActivation
+    alpha::FT = 1.67326
+    lambda::FT = 1.0507
 end
-function apply_scalar_function(sa::Selu, r::Real)
+function apply_scalar_function(sa::Selu, r::FT) where {FT <: AbstractFloat}
     return r > 0 ? sa.lambda * r : sa.lambda * sa.alpha * (exp(r) - 1.0)
 end
 
 """
 $(TYPEDEF)
 """
-@kwdef struct SmoothHeaviside <: ScalarActivation
-    epsilon::Real = 0.01
+@kwdef struct SmoothHeaviside{FT <: AbstractFloat} <: ScalarActivation
+    epsilon::FT = 0.01
 end
-function apply_scalar_function(sa::SmoothHeaviside, r::Real)
+function apply_scalar_function(sa::SmoothHeaviside, r::FT) where {FT <: AbstractFloat}
     return 1 / 2 + (1 / pi) * atan(r / sa.epsilon)
 end

--- a/test/Utilities/runtests.jl
+++ b/test/Utilities/runtests.jl
@@ -54,7 +54,7 @@ using RandomFeatures.Utilities
     xchol = Decomposition(x, "cholesky")
     xpinv = Decomposition(x, "pinv")
 
-    xbad = [1 1; 1 0] # not pos def
+    xbad = [1.0 1.0; 1.0 0.0] # not pos def
     xbadchol = Decomposition(xbad, "cholesky")
     @test isposdef(get_full_matrix(xbadchol))
 
@@ -70,7 +70,7 @@ using RandomFeatures.Utilities
     @test xcholsolve ≈ xsolve
     @test xpinvsolve ≈ xsolve
 
-    y = [x for i in 1:N, x in 1:N]
+    y = Float64[x for i in 1:N, x in 1:N]
     ypinv = Decomposition(y, "pinv")
     @test get_decomposition(ypinv) == pinv(y)
     @test get_parametric_type(ypinv) == PseInv


### PR DESCRIPTION
In this PR
- Woodbury acceleration for `predict_cov`
- `predict!()` into preallocated arrays
-  `AbstractType` -> `T ... where {T <: AbstractType}`
- removed `cat(X...)` calls
these lead to reduction of memory and increase of speed by ~2-3 times in `nd_to_md_regression_direct_withcov.jl` example (and in CES's GCM example or branch `orad/RF`) 

Also 
- discovered the bottleneck of the code, calculation of `PhiTPhi` in `Methods.jl` line 232
- attempt to accelerate this with svd, with no success 

I'm sure further acceleration is possible, as there appears to be still a 50% recompilation time on subsequent calls to codes in the REPL.

- [x] I have read and checked the items on the review checklist.
