### PR TITLE
multithreading flags

### DIFF
--- a/docs/src/parallelism.md
+++ b/docs/src/parallelism.md
@@ -12,8 +12,14 @@
 
 # Parallelism/memory
 - We make use of [`Tullio.jl`](https://github.com/mcabbott/Tullio.jl) which comes with in-built memory management. We are phasing out our own batches in favour of using this for now.
-- [`Tullio.jl`(https://github.com/mcabbott/Tullio.jl) comes with multithreading routines, Simply call the code with `julia --project -t n_threads` to take advantage of this
-!!! note
-    (Hopefully coming soon) We do not yet have GPU functionality
+- [`Tullio.jl`(https://github.com/mcabbott/Tullio.jl) comes with multithreading routines, Simply call the code with `julia --project -t n_threads` to take advantage of this. Depending on problem size you may wish to use your own external threading, Tullio will greedily steal threads in this case. To prevent this interference we provide a keyword argument: 
+```julia
+RandomFeatureMethod(... ; tullio_threading=false) # serial threading during the build and fit! methods
+predict(...; tullio_threading=false) # serial threading for prediction
+predict!(...; tullio_threading=false) # serial threading for in-place prediction
+```
+An example where `tullio_threading=false` is useful is when optimizing hyperparameters with ensemble methods (see our examples), here one could use threading/multiprocessing approaches across ensemble members to make better use of the embarassingly parallel framework (e.g. see this page for [EnsembleKalmanProcessess: Parallelism and HPC](https://clima.github.io/EnsembleKalmanProcesses.jl/dev/parallel_hpc/). 
 
-- If optimizing hyperparameters with ensemble methods, one can use MPI approaches across each ensemble member to make better use of the embarassingly parallel framework (e.g. see this page for [EnsembleKalmanProcessess: Parallelism and HPC](https://clima.github.io/EnsembleKalmanProcesses.jl/dev/parallel_hpc/)
+!!! note
+    We do not yet have GPU functionality
+


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
- Closes #31
Note one side effect of `LoopVectorization` seems to be very slow compile time for github actions (though locally I don't see this)
## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
Adds 2 flags
- one for the training (`RandomFeatureMethod( ...; tullio_multithreading = true)`)
- one for predict (for `predict(...; tullio_multithreading=true)` and `predict!`)
- small docs, and testing for flags (for one thread)
- less code duplication for `predict`

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
