### PR TITLE
Changing how we deal with Regularization

### DIFF
--- a/docs/src/parallelism.md
+++ b/docs/src/parallelism.md
@@ -3,16 +3,16 @@
 ### Explicit bottlenecks
 - By far the highest computational demand for high-dimensional and/or large data systems is the building of the system matrix, particularly the multiplication ``\Phi^T\Phi`` (for scalar) and ``\Phi_{n,i,m}\Phi_{n,j,m}``. These can be accelerated by multithreading (see below)
 - For large number of features, the inversion `inv(factorization(system_matrix))` is noticeable, though typically still small when in the regime of `n_features << n_samples * output_dim`.
-- For the vector case, the use of non-diagonal ``\Lambda_{i,j}`` for regularization cannot take advantage of certain matrix-tensor identities and may also cause substantial slow-down. (currently)
+- For the vector case, the square output-dimensional regularization matrix ``\Lambda`` must be inverted. For high-dimensional spaces, diagonal approximation will avoid this.
 - Prediction bottlenecks are largely due to allocations and matrix multiplications. Please see our `predict!()` methods which allow for users to pass in preallocated of arrays. This is very beneficial for repeated predictions.
 - For systems without enough regularization, positive definiteness may need to be enforced. If done too often, it has non-negligible cost, as it involves calculating eigenvalues of the non p.d. matrix (particularly `abs(min(eigval)`) that is then added to the diagonal. It is better to add more regularization into ``\Lambda``
 
 ### Implicit bottlenecks
-- The optimization of hyperparameters is a costly operation that may require construction and evaluation of thousands of `RandomFeatureMethod`s. The dimensionality (i.e. complexity) of this task will depend on how many free parameters are taken to be within a distribution though. ``\mathcal{O}(1000s)`` parameters may take several hours to optimize (on multiple threads).
+- The optimization of hyperparameters is a costly operation that may require construction and evaluation of thousands of `RandomFeatureMethod`s. The dimensionality (i.e. complexity) of this task will depend on how many free parameters are taken to be within a distribution though. ``\mathcal{O}(1000s)`` parameters may take even hours to optimize (on multiple threads).
 
 # Parallelism/memory
 - We make use of [`Tullio.jl`](https://github.com/mcabbott/Tullio.jl) which comes with in-built memory management. We are phasing out our own batches in favour of using this for now.
-- [`Tullio.jl`(https://github.com/mcabbott/Tullio.jl) comes with multithreading routines, Simply call the code with `julia --project -t n_threads` to take advantage of this. Depending on problem size you may wish to use your own external threading, Tullio will greedily steal threads in this case. To prevent this interference we provide a keyword argument: 
+- [`Tullio.jl`](https://github.com/mcabbott/Tullio.jl) comes with multithreading routines, Simply call the code with `julia --project -t n_threads` to take advantage of this. Depending on problem size you may wish to use your own external threading, Tullio will greedily steal threads in this case. To prevent this interference we provide a keyword argument: 
 ```julia
 RandomFeatureMethod(... ; tullio_threading=false) # serial threading during the build and fit! methods
 predict(...; tullio_threading=false) # serial threading for prediction

--- a/docs/src/setting_up_scalar.md
+++ b/docs/src/setting_up_scalar.md
@@ -111,9 +111,9 @@ The keyword `feature_parameters = Dict("sigma" => a)`, can be included to set th
 
 The `RandomFeatureMethod` sets up the training problem to learn coefficients ``\beta\in\mathbb{R}^m`` from input-output training data ``(x,y)=\{(x_i,y_i)\}_{i=1}^n``, ``y_i \in \mathbb{R}`` and parameters ``\theta = \{\theta_j\}_{j=1}^m``:
 ```math
-(\frac{1}{m}\Phi^T(x;\theta) \Phi(x;\theta) + \lambda I) \beta = \Phi^T(x;\theta)y
+(\frac{1}{\lambda m}\Phi^T(x;\theta) \Phi(x;\theta) + I) \beta = \frac{1}{\lambda}\Phi^T(x;\theta)y
 ```
-Where ``\lambda I`` is a regularization.
+Where ``\lambda>0`` is a regularization parameter that effects the `+I`. The equation is written in this way to be consistent with the vector-output case.
 ```julia
 rfm = RandomFeatureMethod(
     sf;

--- a/docs/src/setting_up_vector.md
+++ b/docs/src/setting_up_vector.md
@@ -115,20 +115,11 @@ The keyword `feature_parameters = Dict("sigma" => a)`, can be included to set th
 
 ## Method
 
-The `RandomFeatureMethod` sets up the training problem to learn coefficients ``\beta\in\mathbb{R}^m`` from input-output training data ``(x,y)=\{(x_i,y_i)\}_{i=1}^n``, ``y_i \in \mathbb{R}^p``  and parameters ``\theta = \{\theta_j\}_{j=1}^m``. Regularization is provided through ``\Lambda = \lambda \otimes I_{n\times n}`` from a user-provided `p-by-p` positive-definite regularization matrix ``\lambda``. In Einstein summation notation the method solves the following system
+The `RandomFeatureMethod` sets up the training problem to learn coefficients ``\beta\in\mathbb{R}^m`` from input-output training data ``(x,y)=\{(x_i,y_i)\}_{i=1}^n``, ``y_i \in \mathbb{R}^p``  and parameters ``\theta = \{\theta_j\}_{j=1}^m``. Regularization is provided through ``\Lambda``, a user-provided `p-by-p` positive-definite regularization matrix (or scaled identity). In Einstein summation notation the method solves the following system
 ```math
-(\frac{1}{m}\Phi_{n,i,p}(x;\theta) \Phi_{n,j,p}(x;\theta) + R_{i,j}) \beta_j = \Phi(x;\theta)_{n,i,p}y_{n,p}
+(\frac{1}{m}\Phi_{n,i,p}(x;\theta) I_{n,m} \otimes \Lambda^{-1}_{p,q} \Phi_{n,j,q}(x;\theta) + I_{i,j}) \beta_j = \Phi(x;\theta)_{n,i,p} I_{n,m} \otimes \Lambda^{-1}_{p,q} y_{n,p}
 ```
-and where the regularization ``R`` is built from ``\Lambda`` by solving the non-square system
-```math
- \Phi_{m,j,q} R_{i,j} = \Phi_{n,i,p} \Lambda_{p,q,n,m}
-```
-In the case the ``\lambda`` is provided as a `Real` or `UniformScaling` then ``R`` is (consistently) replaced with ``\lambda I_{m\times m}``. The authors typically recommend replacing non-diagonal ``\lambda`` with ``\mathrm{det}(\lambda)^{\frac{1}{p}}I``, which often provides a reasonable approximation, as there is additional computational expense through solving this un-batched system of equations.
-
-!!! note "The nonsquare system"
-    If one chooses to solve for ``R``, note that it is also only defined for dimensions ``m < np``. For stability we also perform the following: we use a truncated SVD for when the rank of the system is less than ``m``, and we also symmetrize the resulting matrix.
-
-
+So long as ``\Lambda`` is easily invertible then this system is efficiently solved.       
 
 ```julia
 rfm = RandomFeatureMethod(
@@ -141,7 +132,8 @@ One can select batch sizes to balance the space-time (memory-process) trade-off.
 
 !!! warning "Conditioning"
     The problem is ill-conditioned without regularization.
-    If you encounters a Singular or Positive-definite exceptions, try increasing the constant scaling `regularization`
+    If you encounters a Singular or Positive-definite exceptions or warnings, try increasing the constant scaling `regularization`. 
+   
 
 
 

--- a/docs/src/setting_up_vector.md
+++ b/docs/src/setting_up_vector.md
@@ -117,7 +117,7 @@ The keyword `feature_parameters = Dict("sigma" => a)`, can be included to set th
 
 The `RandomFeatureMethod` sets up the training problem to learn coefficients ``\beta\in\mathbb{R}^m`` from input-output training data ``(x,y)=\{(x_i,y_i)\}_{i=1}^n``, ``y_i \in \mathbb{R}^p``  and parameters ``\theta = \{\theta_j\}_{j=1}^m``. Regularization is provided through ``\Lambda``, a user-provided `p-by-p` positive-definite regularization matrix (or scaled identity). In Einstein summation notation the method solves the following system
 ```math
-(\frac{1}{m}\Phi_{n,i,p}(x;\theta) I_{n,m} \otimes \Lambda^{-1}_{p,q} \Phi_{n,j,q}(x;\theta) + I_{i,j}) \beta_j = \Phi(x;\theta)_{n,i,p} I_{n,m} \otimes \Lambda^{-1}_{p,q} y_{n,p}
+(\frac{1}{m}\Phi_{n,i,p}(x;\theta) \, [I_{n,m} \otimes \Lambda^{-1}_{p,q}]\, \Phi_{n,j,q}(x;\theta) + I_{i,j}) \beta_j = \Phi(x;\theta)_{n,i,p}\,[ I_{n,m} \otimes \Lambda^{-1}_{p,q}]\, y_{n,p}
 ```
 So long as ``\Lambda`` is easily invertible then this system is efficiently solved.       
 

--- a/examples/Learn_hyperparameters/1d_to_1d_regression_direct.jl
+++ b/examples/Learn_hyperparameters/1d_to_1d_regression_direct.jl
@@ -158,7 +158,7 @@ date_of_run = Date(2024, 4, 10)
 # Target function
 ftest(x::AbstractVecOrMat) = exp.(-0.5 * x .^ 2) .* (x .^ 4 - x .^ 3 - x .^ 2 + x .- 1)
 
-n_data = 20 * 2 
+n_data = 20 * 2
 noise_sd = 0.1
 
 x = rand(rng, Uniform(-3, 3), n_data)
@@ -311,7 +311,7 @@ if PLOT_FLAG
     for (idx, rfm, fit, feature_type, clr) in zip(collect(1:length(σ_c)), rfms, fits, feature_types, clrs)
 
         pred_mean, pred_cov = predict(rfm, fit, DataContainer(xplt))
-        pred_cov = pred_cov[1,1,:] #just variances
+        pred_cov = pred_cov[1, 1, :] #just variances
         pred_cov = max.(pred_cov, 0.0) #not normally needed..
         plot!(
             xplt',

--- a/examples/Learn_hyperparameters/1d_to_1d_regression_direct.jl
+++ b/examples/Learn_hyperparameters/1d_to_1d_regression_direct.jl
@@ -86,7 +86,7 @@ function calculate_mean_and_coeffs(
     batch_inputs = batch_generator(itest, test_batch_size, dims = 2) # input_dim x batch_size
 
     #we want to calc lambda/m * coeffs^2 in the end
-    pred_mean = predictive_mean(rfm, fitted_features, DataContainer(itest))
+    pred_mean, features = predictive_mean(rfm, fitted_features, DataContainer(itest))
     scaled_coeffs = sqrt(1 / n_features) * get_coeffs(fitted_features)
     return pred_mean, scaled_coeffs
 
@@ -152,13 +152,13 @@ end
 ## Begin Script, define problem setting
 
 println("starting script")
-date_of_run = Date(2022, 9, 14)
+date_of_run = Date(2024, 4, 10)
 
 
 # Target function
 ftest(x::AbstractVecOrMat) = exp.(-0.5 * x .^ 2) .* (x .^ 4 - x .^ 3 - x .^ 2 + x .- 1)
 
-n_data = 20 * 4
+n_data = 20 * 2 
 noise_sd = 0.1
 
 x = rand(rng, Uniform(-3, 3), n_data)
@@ -285,7 +285,7 @@ for (idx, sd, feature_type) in zip(collect(1:length(σ_c)), σ_c, feature_types)
     end
 
     push!(rfms, RandomFeatureMethod(sf, batch_sizes = batch_sizes, regularization = regularizer))
-    push!(fits, fit(rfms[end], io_pairs_test, decomposition_type = "qr"))
+    push!(fits, fit(rfms[end], io_pairs_test))
 end
 
 if PLOT_FLAG
@@ -311,7 +311,8 @@ if PLOT_FLAG
     for (idx, rfm, fit, feature_type, clr) in zip(collect(1:length(σ_c)), rfms, fits, feature_types, clrs)
 
         pred_mean, pred_cov = predict(rfm, fit, DataContainer(xplt))
-        pred_cov = max.(pred_cov, 0.0)
+        pred_cov = pred_cov[1,1,:] #just variances
+        pred_cov = max.(pred_cov, 0.0) #not normally needed..
         plot!(
             xplt',
             pred_mean',

--- a/examples/Learn_hyperparameters/1d_to_1d_regression_direct_withcov.jl
+++ b/examples/Learn_hyperparameters/1d_to_1d_regression_direct_withcov.jl
@@ -157,7 +157,7 @@ end
 ## Begin Script, define problem setting
 
 println("starting script")
-date_of_run = Date(2022, 9, 14)
+date_of_run = Date(2024, 4, 10)
 
 
 # Target function
@@ -254,7 +254,7 @@ for (idx, type) in enumerate(feature_types)
             string(i) *
             ", Error: " *
             string(err[i]) *
-            ", with parameter mean" *
+            ", with parameter mean " *
             string(mean(transform_unconstrained_to_constrained(priors, get_u_final(ekiobj[1])), dims = 2)[:, 1]),
             " and sd ",
             string(sqrt.(var(transform_unconstrained_to_constrained(priors, get_u_final(ekiobj[1])), dims = 2))[:, 1]),
@@ -298,7 +298,7 @@ for (idx, sd, feature_type) in zip(collect(1:length(σ_c)), σ_c, feature_types)
     end
 
     push!(rfms, RandomFeatureMethod(sf, batch_sizes = batch_sizes, regularization = regularizer))
-    push!(fits, fit(rfms[end], io_pairs_test, decomposition_type = "qr"))
+    push!(fits, fit(rfms[end], io_pairs_test))
 end
 
 if PLOT_FLAG

--- a/examples/Learn_hyperparameters/nd_to_1d_regression_direct.jl
+++ b/examples/Learn_hyperparameters/nd_to_1d_regression_direct.jl
@@ -362,8 +362,8 @@ if PLOT_FLAG
         yslice = ftest_nd_to_1d(xslicenew)
 
         pred_mean_slice, pred_cov_slice = predict(rfm_batch, fitted_batched_features, DataContainer(xslicenew))
-        pred_cov_slice = max.(pred_cov_slice[1,1,:], 0.0)
-        
+        pred_cov_slice = max.(pred_cov_slice[1, 1, :], 0.0)
+
         plt = plot(
             xrange,
             yslice',

--- a/examples/Learn_hyperparameters/nd_to_1d_regression_direct.jl
+++ b/examples/Learn_hyperparameters/nd_to_1d_regression_direct.jl
@@ -93,13 +93,13 @@ function calculate_mean_and_coeffs(
 
     # build and fit the RF
     rfm = RFM_from_hyperparameters(rng, l, regularizer, n_features, batch_sizes, input_dim)
-    fitted_features = fit(rfm, io_train_cost, decomposition_type = "qr")
+    fitted_features = fit(rfm, io_train_cost)
 
     test_batch_size = get_batch_size(rfm, "test")
     batch_inputs = batch_generator(itest, test_batch_size, dims = 2) # input_dim x batch_size
 
     #we want to calc 1/var(y-mean)^2 + lambda/m * coeffs^2 in the end
-    pred_mean = predictive_mean(rfm, fitted_features, DataContainer(itest))
+    pred_mean, features = predictive_mean(rfm, fitted_features, DataContainer(itest))
     scaled_coeffs = sqrt(1 / n_features) * get_coeffs(fitted_features)
     return pred_mean, scaled_coeffs
 
@@ -169,7 +169,7 @@ end
 
 ## Begin Script, define problem setting
 println("Begin script")
-date_of_run = Date(2022, 9, 14)
+date_of_run = Date(2024, 4, 10)
 input_dim = 6
 println("Number of input dimensions: ", input_dim)
 
@@ -344,7 +344,7 @@ sff = ScalarFourierFeature(n_features_test, feature_sampler)
 #second case with batching
 
 rfm_batch = RandomFeatureMethod(sff, batch_sizes = batch_sizes, regularization = regularizer)
-fitted_batched_features = fit(rfm_batch, io_pairs_test, decomposition_type = "qr")
+fitted_batched_features = fit(rfm_batch, io_pairs_test)
 
 if PLOT_FLAG
     #plot slice through one dimensions, others fixed to 0
@@ -362,7 +362,8 @@ if PLOT_FLAG
         yslice = ftest_nd_to_1d(xslicenew)
 
         pred_mean_slice, pred_cov_slice = predict(rfm_batch, fitted_batched_features, DataContainer(xslicenew))
-        pred_cov_slice = max.(pred_cov_slice, 0.0)
+        pred_cov_slice = max.(pred_cov_slice[1,1,:], 0.0)
+        
         plt = plot(
             xrange,
             yslice',

--- a/examples/Learn_hyperparameters/nd_to_1d_regression_direct_matchingcov.jl
+++ b/examples/Learn_hyperparameters/nd_to_1d_regression_direct_matchingcov.jl
@@ -93,7 +93,7 @@ function calculate_mean_cov_and_coeffs(
 
     # build and fit the RF
     rfm = RFM_from_hyperparameters(rng, l, regularizer, n_features, batch_sizes, input_dim)
-    fitted_features = fit(rfm, io_train_cost, decomposition_type = "svd")
+    fitted_features = fit(rfm, io_train_cost)
 
     test_batch_size = get_batch_size(rfm, "test")
     batch_inputs = batch_generator(itest, test_batch_size, dims = 2) # input_dim x batch_size
@@ -174,7 +174,7 @@ end
 
 ## Begin Script, define problem setting
 println("Begin script")
-date_of_run = Date(2022, 9, 22)
+date_of_run = Date(2024, 4, 10)
 input_dim_list = [8]
 
 for input_dim in input_dim_list
@@ -368,7 +368,7 @@ for input_dim in input_dim_list
     #second case with batching
 
     rfm_batch = RandomFeatureMethod(sff, batch_sizes = batch_sizes, regularization = regularizer)
-    fitted_batched_features = fit(rfm_batch, io_pairs_test, decomposition_type = "svd")
+    fitted_batched_features = fit(rfm_batch, io_pairs_test)
 
     if PLOT_FLAG
         #plot slice through one dimensions, others fixed to 0

--- a/examples/Learn_hyperparameters/nd_to_1d_regression_direct_withcov.jl
+++ b/examples/Learn_hyperparameters/nd_to_1d_regression_direct_withcov.jl
@@ -93,7 +93,7 @@ function calculate_mean_cov_and_coeffs(
 
     # build and fit the RF
     rfm = RFM_from_hyperparameters(rng, l, regularizer, n_features, batch_sizes, input_dim)
-    fitted_features = fit(rfm, io_train_cost, decomposition_type = "qr")
+    fitted_features = fit(rfm, io_train_cost)
 
     test_batch_size = get_batch_size(rfm, "test")
     batch_inputs = batch_generator(itest, test_batch_size, dims = 2) # input_dim x batch_size
@@ -173,7 +173,7 @@ end
 
 ## Begin Script, define problem setting
 println("Begin script")
-date_of_run = Date(2022, 9, 14)
+date_of_run = Date(2024, 4, 10)
 input_dim = 8
 println("Number of input dimensions: ", input_dim)
 
@@ -352,7 +352,7 @@ sff = ScalarFourierFeature(n_features_test, feature_sampler)
 #second case with batching
 
 rfm_batch = RandomFeatureMethod(sff, batch_sizes = batch_sizes, regularization = regularizer)
-fitted_batched_features = fit(rfm_batch, io_pairs_test, decomposition_type = "svd")
+fitted_batched_features = fit(rfm_batch, io_pairs_test)
 
 if PLOT_FLAG
     #plot slice through one dimensions, others fixed to 0
@@ -368,9 +368,8 @@ if PLOT_FLAG
         xslicenew[direction, :] = xrange
 
         yslice = ftest_nd_to_1d(xslicenew)
-
         pred_mean_slice, pred_cov_slice = predict(rfm_batch, fitted_batched_features, DataContainer(xslicenew))
-        pred_cov_slice[1, 1, :] = max.(pred_cov_slice[1, 1, :], 0.0)
+        pred_cov_slice = max.(pred_cov_slice[1, 1, :], 0.0)
         plt = plot(
             xrange,
             yslice',
@@ -384,7 +383,7 @@ if PLOT_FLAG
         plot!(
             xrange,
             pred_mean_slice',
-            ribbon = [2 * sqrt.(pred_cov_slice[1, 1, :]); 2 * sqrt.(pred_cov_slice[1, 1, :])]',
+            ribbon = [2 * sqrt.(pred_cov_slice); 2 * sqrt.(pred_cov_slice)]',
             label = "Fourier",
             color = "blue",
         )

--- a/examples/Learn_hyperparameters/nd_to_md_regression_direct_withcov.jl
+++ b/examples/Learn_hyperparameters/nd_to_md_regression_direct_withcov.jl
@@ -454,17 +454,6 @@ end
     initial_params = construct_initial_ensemble(priors, N_ens; rng_seed = ekp_seed)
     params_init = transform_unconstrained_to_constrained(priors, initial_params)#[1, :]
     println("Prior gives parameters between: [$(minimum(params_init)),$(maximum(params_init))]")
-
-    #=
-    min_complexity =
-        isa(lambda, UniformScaling) ? n_features_opt * log(lambda.λ) :
-        n_features_opt / output_dim * 2 * sum(log.(diag(cholesky(lambda).L)))
-    min_complexity = sqrt(abs(min_complexity))
-
-
-    data = vcat(reshape(y[:, (n_train + 1):end], :, 1), 0.0, min_complexity) #flatten data
-    println("min_complexity: ", min_complexity)
-    =#
     data = zeros(size(Γ, 1))
 
 

--- a/src/Methods.jl
+++ b/src/Methods.jl
@@ -66,6 +66,7 @@ function RandomFeatureMethod(
         throw(ArgumentError("batch_sizes keys must contain all of \"train\", \"test\", and \"feature\""))
     end
 
+    # ToDo store cholesky factors
     if isa(regularization, Real)
         if regularization <= 0
             @info "input regularization <=0 is invalid, using regularization = 1e12*eps()"
@@ -215,7 +216,7 @@ function fit(
         else
             @tullio threads = 10^9 PhiTλinv[n, q, i] = Phi[n, p, i] * λinv[p, q]
         end
-        @tullio threads = 10^9 PhiTλinvY[j] = PhiTλinv[n, p, j] * output[q, n]
+        @tullio threads = 10^9 PhiTλinvY[j] = PhiTλinv[n, p, j] * output[p, n]
         @tullio threads = 10^9 PhiTλinvPhi[i, j] = PhiTλinv[n, p, i] * Phi[n, p, j] # BOTTLENECK
     else
         if isa(λinv, UniformScaling)

--- a/src/Methods.jl
+++ b/src/Methods.jl
@@ -67,7 +67,7 @@ function RandomFeatureMethod(
     end
 
     if isa(regularization, Real)
-        if regularization <=0
+        if regularization <= 0
             @info "input regularization <=0 is invalid, using regularization = 1e12*eps()"
             λ = 1e12 * eps() * I
         else
@@ -78,7 +78,7 @@ function RandomFeatureMethod(
             tol = 1e12 * eps() #MAGIC NUMBER
             λ = posdef_correct(regularization, tol = tol)
             @warn "input regularization matrix is not positive definite, replacing with nearby positive definite matrix"
-        else     
+        else
             λ = regularization
         end
     end
@@ -92,7 +92,7 @@ function RandomFeatureMethod(
     else
         λinv = λ
     end
-    
+
     return RandomFeatureMethod{S, typeof(λ)}(random_feature, batch_sizes, λinv, tullio_threading)
 end
 
@@ -205,10 +205,10 @@ function fit(
     λinv = get_regularization(rfm)
     Phi = build_features(rf, input)
     FT = eltype(Phi)
-        
+
     PhiTλinv = zeros(size(Phi))
-    PhiTλinvY = zeros(n_features) 
-    PhiTλinvPhi = zeros(n_features, n_features) 
+    PhiTλinvY = zeros(n_features)
+    PhiTλinvPhi = zeros(n_features, n_features)
     if !tullio_threading
         if isa(λinv, UniformScaling)
             PhiTλinv = Phi * λinv.λ
@@ -239,7 +239,7 @@ function fit(
     end
     feature_factors = Decomposition(PhiTλinvPhi, decomposition_type)
     # bottleneck for small problems only (much quicker than PhiTPhi for big problems)
-    
+
     coeffs = linear_solve(feature_factors, PhiTλinvY, tullio_threading = tullio_threading) #n_features x n_samples x dim_output
 
     return Fit{typeof(coeffs), typeof(λinv)}(feature_factors, coeffs, λinv)
@@ -557,15 +557,15 @@ function predictive_cov!(
             ),
         )
     end
-    
+
     if !tullio_threading
         @tullio threads = 10^9 buffer[n, p, o] = prebuilt_features[n, p, m] * inv_decomp[m, o] # = betahat(x')
-        @tullio threads = 10^9 cov_store[p, q, n] = buffer[n, p, o] * prebuilt_features[n, q, o] 
+        @tullio threads = 10^9 cov_store[p, q, n] = buffer[n, p, o] * prebuilt_features[n, q, o]
     else
         @tullio buffer[n, p, o] = prebuilt_features[n, p, m] * inv_decomp[m, o] # = betahat(x')
         @tullio cov_store[p, q, n] = buffer[n, p, o] * prebuilt_features[n, q, o]
     end
-    @. cov_store /= FT(n_features) 
+    @. cov_store /= FT(n_features)
 
     nothing
 end

--- a/src/Methods.jl
+++ b/src/Methods.jl
@@ -65,8 +65,8 @@ function RandomFeatureMethod(
         throw(ArgumentError("batch_sizes keys must contain all of \"train\", \"test\", and \"feature\""))
     end
     if isa(regularization, Real)
-        if regularization < 0
-            @info "input regularization < 0 is invalid, using regularization = 1e12*eps()"
+        if regularization <=0
+            @info "input regularization <=0 is invalid, using regularization = 1e12*eps()"
             lambda = 1e12 * eps() * I
         else
             lambda = regularization * I
@@ -137,11 +137,11 @@ Holds the coefficients and matrix decomposition that describe a set of fitted ra
 $(TYPEDFIELDS)
 """
 struct Fit{V <: AbstractVector, USorM <: Union{UniformScaling, AbstractMatrix}}
-    "The `LinearAlgreba` matrix decomposition of `(1 / m) * Feature^T * Feature + regularization`"
+    "The `LinearAlgreba` matrix decomposition of `(1 / m) * Feature^T * regularization^-1 * Feature + I`"
     feature_factors::Decomposition
     "Coefficients of the fit to data"
     coeffs::V
-    "feature-space regularization used during fit"
+    "output-dim regularization used during fit"
     regularization::USorM
 end
 
@@ -163,7 +163,7 @@ get_coeffs(f::Fit) = f.coeffs
 """
 $(TYPEDSIGNATURES)
 
-gets the `regularization` field (note this is the feature-space regularization)
+gets the `regularization` field (note this is the outputdim regularization)
 """
 get_regularization(f::Fit) = f.regularization
 
@@ -192,95 +192,49 @@ function fit(
     #data are columns, batch over samples
 
     lambda = get_regularization(rfm)
-    build_regularization = !isa(lambda, UniformScaling) # build if lambda is not a uniform scaling
-    if build_regularization
-        lambda_new = zeros(n_features, n_features)
-    else
-        lambda_new = lambda
-    end
     Phi = build_features(rf, input)
     FT = eltype(Phi)
-
-    # regularization build needed with p.d matrix lambda
-    if build_regularization
-        if output_dim * n_data < n_features
-            lambda_new = exp(1.0 / output_dim * log(det(lambda))) * I #det(X)^{1/m}
-            @info(
-                "pos-def regularization formulation ill-defined for output_dim ($output_dim) * n_data ($n_data) < n_feature ($n_features). \n Treating it as if regularization was a uniform scaling size det(regularization_matrix)^{1 / output_dim}: $(lambda_new.λ)"
-            )
-        else
-
-            if !isa(lambda, Diagonal)
-                if !tullio_threading
-                    @tullio threads = 10^9 lambdaT_times_phi[n, p, i] := lambda[q, p] * Phi[n, q, i] # (I ⊗ Λᵀ) Φ
-                else
-                    @tullio lambdaT_times_phi[n, p, i] := lambda[q, p] * Phi[n, q, i] # (I ⊗ Λᵀ) Φ
-                end
-            else
-                lam_diag = [lambda[i, i] for i in 1:size(lambda, 1)]
-
-                if !tullio_threading
-                    @tullio threads = 10^9 lambdaT_times_phi[n, p, i] := lam_diag[p] * Phi[n, p, i] # (I ⊗ Λᵀ) Φ
-                else
-                    @tullio lambdaT_times_phi[n, p, i] := lam_diag[p] * Phi[n, p, i] # (I ⊗ Λᵀ) Φ                
-                end
-            end
-            #reshape to stacks columns, i.e n,p -> np does (n,...,n) p times
-            rhs = reshape(permutedims(lambdaT_times_phi, (2, 1, 3)), (n_data * output_dim, n_features))
-            lhs = reshape(permutedims(Phi, (2, 1, 3)), (n_data * output_dim, n_features))
-
-            # Solve Φ Bᵀ = (I ⊗ Λᵀ) Φ and transpose for B (=lambda_new)
-            lhs_svd = svd(lhs) #stable solve of rank deficient systems with SVD
-            th_idx = 1:sum(lhs_svd.S .> 1e-2 * maximum(lhs_svd.S))
-            lambda_new =
-                lhs_svd.V[:, th_idx] *
-                Diagonal(1 ./ lhs_svd.S[th_idx]) *
-                permutedims(lhs_svd.U[:, th_idx], (2, 1)) *
-                rhs
-            #make positive definite
-            lambda_new = posdef_correct(lambda_new)
-
-        end
-    end
-
-    PhiTY = zeros(n_features) #
-    PhiTPhi = zeros(n_features, n_features)
+        
+    PhiTλinv = zeros(size(Phi))
+    PhiTλinvY = zeros(n_features) 
+    PhiTλinvPhi = zeros(n_features, n_features) 
     if !tullio_threading
-        @tullio threads = 10^9 PhiTY[j] = Phi[n, p, j] * output[p, n]
-        @tullio threads = 10^9 PhiTPhi[i, j] = Phi[n, p, i] * Phi[n, p, j] # BOTTLENECK
+        if isa(lambda, UniformScaling)
+            PhiTλinv = Phi / FT(lambda.λ)
+        else
+            λinv = inv(lambda) # must be PD?
+            @tullio threads = 10^9 PhiTλinv[n, q, i] = Phi[n, p, i] * λinv[p, q]
+        end
+        @tullio threads = 10^9 PhiTλinvY[j] = PhiTλinv[n, p, j] * output[q, n]
+        @tullio threads = 10^9 PhiTλinvPhi[i, j] = PhiTλinv[n, p, i] * Phi[n, p, j] # BOTTLENECK
     else
-        @tullio PhiTY[j] = Phi[n, p, j] * output[p, n]
-        @tullio PhiTPhi[i, j] = Phi[n, p, i] * Phi[n, p, j] # BOTTLENECK
+        if isa(lambda,UniformScaling)
+            PhiTλinv = Phi / FT(lambda.λ)
+        else
+            λinv = inv(lambda) # must be PD?
+            @tullio PhiTλinv[n, q, i] = Phi[n, p, i] * λinv[p, q]
+        end
+        @tullio PhiTλinvY[j] = PhiTλinv[n, p, j] * output[p, n]
+        @tullio PhiTλinvPhi[i, j] = PhiTλinv[n, p, i] * Phi[n, p, j] # BOTTLENECK
     end
     # alternative using svd - turns out to be slower and more mem intensive
 
-    @. PhiTPhi /= FT(n_features)
+    @. PhiTλinvPhi /= FT(n_features)
 
     # solve the linear system
-    # (PhiTPhi + lambda_new ) * beta = PhiTY
+    # (PhiTλinvPhi + I) * beta = PhiTλinvY
 
-    if lambda_new == 0 * I
-        feature_factors = Decomposition(PhiTPhi, "pinv")
-    else
-        # in-place add lambda (as we don't use PhiTPhi again after this)
-        if isa(lambda_new, UniformScaling)
-            # much quicker than just adding lambda_new...
-            for i in 1:size(PhiTPhi, 1)
-                PhiTPhi[i, i] += lambda_new.λ
-            end
-        else
-            @. PhiTPhi += lambda_new
-        end
-        feature_factors = Decomposition(PhiTPhi, decomposition_type)
-        # bottleneck for small problems only (much quicker than PhiTPhi for big problems)
-
+    # in-place add I (as we don't use PhiTPhi again after this)
+    for i in 1:size(PhiTλinvPhi, 1)
+        PhiTλinvPhi[i, i] += 1.0
     end
+    feature_factors = Decomposition(PhiTλinvPhi, decomposition_type)
+    # bottleneck for small problems only (much quicker than PhiTPhi for big problems)
+    
+    coeffs = linear_solve(feature_factors, PhiTλinvY, tullio_threading = tullio_threading) #n_features x n_samples x dim_output
 
-    coeffs = linear_solve(feature_factors, PhiTY, tullio_threading = tullio_threading) #n_features x n_samples x dim_output
-
-    return Fit{typeof(coeffs), typeof(lambda_new)}(feature_factors, coeffs, lambda_new)
+    return Fit{typeof(coeffs), typeof(lambda)}(feature_factors, coeffs, lambda)
 end
-
 
 """
     $(TYPEDSIGNATURES)
@@ -575,8 +529,8 @@ function predictive_cov!(
 
     output_dim = get_output_dim(rf)
     coeffs = get_coeffs(fit)
-    PhiTPhi_reg_factors = get_feature_factors(fit)
-    inv_decomp = get_inv_decomposition(PhiTPhi_reg_factors)
+    PhiTλinvPhi_factors = get_feature_factors(fit)
+    inv_decomp = get_inv_decomposition(PhiTλinvPhi_factors) # (get the inverse of this)
     if !(size(cov_store) == (output_dim, output_dim, size(inputs, 2)))
         throw(
             DimensionMismatch(
@@ -586,45 +540,25 @@ function predictive_cov!(
     end
 
     FT = eltype(prebuilt_features)
-    if isa(lambda, UniformScaling)
-        if !(size(buffer) == (size(inputs, 2), output_dim, n_features))
-            throw(
-                DimensionMismatch(
-                    "provided storage for tmp buffer expected to be size ($(size(inputs,2)),$(output_dim),$(n_features)), got $(size(buffer))",
-                ),
-            )
-        end
-        if !tullio_threading
-            @tullio threads = 10^9 buffer[n, p, o] = prebuilt_features[n, p, m] * inv_decomp[m, o]
-            @tullio threads = 10^9 cov_store[p, q, n] = buffer[n, p, o] * prebuilt_features[n, q, o]
-        else
-            @tullio buffer[n, p, o] = prebuilt_features[n, p, m] * inv_decomp[m, o]
-            @tullio cov_store[p, q, n] = buffer[n, p, o] * prebuilt_features[n, q, o]
-        end
-        @. cov_store /= (FT(n_features) / lambda.λ) #i.e. * lambda / n_features
 
-    else
-        PhiTPhi_reg = get_full_matrix(PhiTPhi_reg_factors)
-        @. PhiTPhi_reg -= lambda
-        if !tullio_threading
-            @tullio threads = 10^9 buffer[n, p, i] = PhiTPhi_reg[i, j] * prebuilt_features[n, p, j] # BOTTLENECK OF PREDICTION
-            coeff_outputs = linear_solve(PhiTPhi_reg_factors, buffer, tullio_threading = tullio_threading) # n_features x bsize x output_dim
-            # make sure we don't use := in following line, or it wont modify the input argument.
-            @tullio threads = 10^9 cov_store[p, q, n] =
-                prebuilt_features[n, p, m] * (prebuilt_features[n, q, m] - coeff_outputs[n, q, m])
-        else
-            @tullio buffer[n, p, i] = PhiTPhi_reg[i, j] * prebuilt_features[n, p, j] # BOTTLENECK OF PREDICTION
-            coeff_outputs = linear_solve(PhiTPhi_reg_factors, buffer) # n_features x bsize x output_dim
-            # make sure we don't use := in following line, or it wont modify the input argument.
-            @tullio cov_store[p, q, n] =
-                prebuilt_features[n, p, m] * (prebuilt_features[n, q, m] - coeff_outputs[n, q, m])
-        end
-        @. cov_store /= FT(n_features)
-
-        # IMPORTANT, we remove lambda in-place for calculation only, so must add it back
-        @. PhiTPhi_reg += lambda
-
+    # Bishop Nasrabadi 2006 - efficient computation of cov:   
+    if !(size(buffer) == (size(inputs, 2), output_dim, n_features))
+        throw(
+            DimensionMismatch(
+                "provided storage for tmp buffer expected to be size ($(size(inputs,2)),$(output_dim),$(n_features)), got $(size(buffer))",
+            ),
+        )
     end
+    
+    if !tullio_threading
+        @tullio threads = 10^9 buffer[n, p, o] = prebuilt_features[n, p, m] * inv_decomp[m, o] # = betahat(x')
+        @tullio threads = 10^9 cov_store[p, q, n] = buffer[n, p, o] * prebuilt_features[n, q, o] 
+    else
+        @tullio buffer[n, p, o] = prebuilt_features[n, p, m] * inv_decomp[m, o] # = betahat(x')
+        @tullio cov_store[p, q, n] = buffer[n, p, o] * prebuilt_features[n, q, o]
+    end
+    @. cov_store /= FT(n_features) 
+
     nothing
 end
 

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -45,15 +45,26 @@ end
 
 Makes square matrix `mat` positive definite, by symmetrizing and bounding the minimum eigenvalue below by `tol`
 """
-function posdef_correct(mat::M; tol::R = 1e12 * eps()) where {M <: AbstractMatrix, R <: Float64}
-    out = 0.5 * (mat + permutedims(mat, (2, 1))) #symmetrize
-    abs_min_ev = abs(minimum(eigvals(out)))
-    for i in 1:size(out, 1)
-        out[i, i] += abs_min_ev + tol #add to diag 
+function posdef_correct(mat::AbstractMatrix; tol::Real = 1e12 * eps())
+    mat = deepcopy(mat)
+    if !issymmetric(mat)
+        out = 0.5 * (mat + permutedims(mat, (2, 1))) #symmetrize
+        if isposdef(out)
+            # very often, small numerical errors cause asymmetry, so cheaper to add this branch
+            return out
+        end
+    else
+        out = mat
+    end
+
+    if !isposdef(out)
+        nugget = abs(minimum(eigvals(out)))
+        for i in 1:size(out, 1)
+            out[i, i] += nugget + tol # add to diag
+        end
     end
     return out
 end
-
 
 """
 $(TYPEDEF)
@@ -97,7 +108,7 @@ function Decomposition(
     # TODOs
     # 1. Originally I used  f = getfield(LinearAlgebra, Symbol(method)) but this is slow for evaluation so defining svd and cholesky is all we have now. I could maybe do dispatch here to make this a bit more slick.
     # 2. I have tried using the in-place methods, but so far these have not made enough difference to be worthwhile, I think at some-point they would be, but the original matrix would be needed for matrix regularization. They are not the bottleneck in the end
-    # 3. The 
+
     if method == "pinv"
         invmat = pinv(mat)
         return Decomposition{PseInv, M, M}(mat, invmat, invmat)
@@ -106,7 +117,7 @@ function Decomposition(
         return Decomposition{Factor, typeof(mat), Base.return_types(svd, (typeof(mat),))[1]}(mat, fmat, inv(fmat))
     elseif method == "cholesky"
         if !isposdef(mat)
-            @info "Random Feature system not positive definite. Performing cholesky factorization with a close positive definite matrix"
+#            @info "Random Feature system not positive definite. Performing cholesky factorization with a close positive definite matrix"
             mat = posdef_correct(mat, tol = nugget)
         end
         fmat = cholesky(mat)

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -117,7 +117,7 @@ function Decomposition(
         return Decomposition{Factor, typeof(mat), Base.return_types(svd, (typeof(mat),))[1]}(mat, fmat, inv(fmat))
     elseif method == "cholesky"
         if !isposdef(mat)
-#            @info "Random Feature system not positive definite. Performing cholesky factorization with a close positive definite matrix"
+            #            @info "Random Feature system not positive definite. Performing cholesky factorization with a close positive definite matrix"
             mat = posdef_correct(mat, tol = nugget)
         end
         fmat = cholesky(mat)

--- a/test/Utilities/runtests.jl
+++ b/test/Utilities/runtests.jl
@@ -56,7 +56,6 @@ using RandomFeatures.Utilities
     @test_throws ArgumentError Decomposition(x, "qr")
 
     xbad = [1.0 1.0; 1.0 0.0] # not pos def
-    @test_logs (:info,) Decomposition(xbad, "cholesky")
     xbadchol = Decomposition(xbad, "cholesky")
     @test isposdef(get_full_matrix(xbadchol))
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
 -->
Reduce the cost of regularizing with non-diagonal matrices dramatically. 
Updates many of the examples to work with the latest loss functions 

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- Inverts the regularization matrix prior to solving the linear systems roughly speaking one solves `(A^T (reg)^{-1}A + I)x = reg^{-1}b` replacing  `(A^T A + reg)x = b`
- Updates `posdef_correct` to check if symmetrization is enough to ensure positive definiteness
- Updates examples to work with newer interfaces
- Updates `nd_to_md_regression_direct_withcov.jl` to match to test implementations of loss functions 
- Allow users to provide `inv(lambda)` so as not to internally invert the pxp matrix every time in, say, a hyperparameter learning scenario. set `regularization_inverted = true` flag in method constructor
- Update unit tests
## TODO

- possibly try out new weightings of the loss function in the examples - or leave this for future

## Example: 1d_to_3d_regression

`nd_to_md_regression_direct_withcov.jl` with updated loss and with new matrix solve, the training for the **non-diagonal** example with **non-diagonal regularization** takes 2.3secs and produces:
<img src="https://github.com/CliMA/RandomFeatures.jl/assets/47412152/592ae9e5-079f-43f4-bb9d-cb4cf579c9d4" width="400">

Compared with taking a **diagonal approximation of the regularization** is more prone to over-smoothing
<img src="https://github.com/CliMA/RandomFeatures.jl/assets/47412152/232f822e-ed66-4b89-9c04-edc8c0e099e1" width="400">



<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
