### PR TITLE
New loss functions, and bugfixes for CI pipeline

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
       - run: julia --project -e 'using Pkg; Pkg.update()' #windows in particular sometimes doesnt update packages

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
        matrix:
         version:
-          - '1.6' # Long-Term Support release
+          - 'lts' # Long-Term Support release
           - '1' # Latest 1.x release of julia
         os:
           - ubuntu-latest

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -18,8 +18,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
           - macOS-latest
-        arch:
-          - x64
     steps:
       - uses: styfle/cancel-workflow-action@0.9.1
         with:
@@ -28,7 +26,6 @@ jobs:
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
       - run: julia --project -e 'using Pkg; Pkg.update()' #windows in particular sometimes doesnt update packages
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1

--- a/examples/Learn_hyperparameters/1d_to_1d_regression_direct.jl
+++ b/examples/Learn_hyperparameters/1d_to_1d_regression_direct.jl
@@ -118,7 +118,7 @@ function estimate_mean_and_coeffnorm_covariance(
             means[:, i] += m' / repeats
             coeffl2norm[1, i] += sqrt(sum(c .^ 2)) / repeats
             complexity[1, i] += cplx / repeats
-            
+
         end
     end
 
@@ -224,7 +224,15 @@ for (idx, type) in enumerate(feature_types)
     N_iter = 20
     initial_params = construct_initial_ensemble(rng, priors, N_ens)
     data = vcat(y[(n_train + 1):end], 0.0, 0.0)
-    ekiobj = [EKP.EnsembleKalmanProcess(initial_params, data, Γ, Inversion(), scheduler=DataMisfitController(terminate_at=1000))]
+    ekiobj = [
+        EKP.EnsembleKalmanProcess(
+            initial_params,
+            data,
+            Γ,
+            Inversion(),
+            scheduler = DataMisfitController(terminate_at = 1000),
+        ),
+    ]
 
 
     err = zeros(N_iter)

--- a/examples/Learn_hyperparameters/1d_to_1d_regression_direct_nodatasplit.jl
+++ b/examples/Learn_hyperparameters/1d_to_1d_regression_direct_nodatasplit.jl
@@ -115,7 +115,7 @@ function estimate_mean_and_coeffnorm_covariance(
             means[:, i] += m' / repeats
             coeffl2norm[1, i] += sqrt(sum(c .^ 2)) / repeats
             complexity[1, i] += cplx / repeats
-            
+
         end
     end
 
@@ -218,7 +218,15 @@ for (idx, type) in enumerate(feature_types)
     N_iter = 20
     initial_params = construct_initial_ensemble(rng, priors, N_ens)
     data = vcat(y, 0.0, 0.0)
-    ekiobj = [EKP.EnsembleKalmanProcess(initial_params, data, Γ, Inversion(), scheduler=EKP.DataMisfitController(terminate_at=100))]
+    ekiobj = [
+        EKP.EnsembleKalmanProcess(
+            initial_params,
+            data,
+            Γ,
+            Inversion(),
+            scheduler = EKP.DataMisfitController(terminate_at = 100),
+        ),
+    ]
 
 
     err = zeros(N_iter)

--- a/examples/Learn_hyperparameters/1d_to_1d_regression_direct_withcov.jl
+++ b/examples/Learn_hyperparameters/1d_to_1d_regression_direct_withcov.jl
@@ -220,7 +220,15 @@ for (idx, type) in enumerate(feature_types)
     N_iter = 20
     initial_params = construct_initial_ensemble(rng, priors, N_ens)
     data = vcat(y[(n_train + 1):end], 0.0)
-    ekiobj = [EKP.EnsembleKalmanProcess(initial_params, data, Γ, Inversion(), scheduler = EKP.DataMisfitController(terminate_at=100))]
+    ekiobj = [
+        EKP.EnsembleKalmanProcess(
+            initial_params,
+            data,
+            Γ,
+            Inversion(),
+            scheduler = EKP.DataMisfitController(terminate_at = 100),
+        ),
+    ]
 
 
     err = zeros(N_iter)

--- a/examples/Learn_hyperparameters/1d_to_1d_regression_direct_withcov.jl
+++ b/examples/Learn_hyperparameters/1d_to_1d_regression_direct_withcov.jl
@@ -189,7 +189,7 @@ batch_sizes = Dict("train" => 100, "test" => 100, "feature" => 100)
 n_train = Int(floor(0.8 * n_data))
 n_test = n_data - n_train
 n_samples = n_test + 1 # >  n_test
-n_features = 80
+n_features = 200
 repeats = 1
 
 
@@ -220,7 +220,7 @@ for (idx, type) in enumerate(feature_types)
     N_iter = 20
     initial_params = construct_initial_ensemble(rng, priors, N_ens)
     data = vcat(y[(n_train + 1):end], 0.0)
-    ekiobj = [EKP.EnsembleKalmanProcess(initial_params, data, Γ, Inversion())]
+    ekiobj = [EKP.EnsembleKalmanProcess(initial_params, data, Γ, Inversion(), scheduler = EKP.DataMisfitController(terminate_at=100))]
 
 
     err = zeros(N_iter)

--- a/examples/Learn_hyperparameters/nd_to_1d_regression_direct.jl
+++ b/examples/Learn_hyperparameters/nd_to_1d_regression_direct.jl
@@ -272,15 +272,8 @@ for i in 1:N_iter
 
     #get parameters:
     lvec = transform_unconstrained_to_constrained(priors, get_u_final(ekiobj[1]))
-    g_ens = calculate_ensemble_mean_and_coeffnorm(
-        rng,
-        lvec,
-        noise_sd,
-        n_features,
-        batch_sizes,
-        io_pairs,
-        repeats = repeats,
-    )
+    g_ens =
+        calculate_ensemble_mean_and_coeffnorm(rng, lvec, noise_sd, n_features, batch_sizes, io_pairs, repeats = repeats)
 
     if i % update_cov_step == 0 # one update to the 
 

--- a/examples/Learn_hyperparameters/nd_to_1d_regression_direct.jl
+++ b/examples/Learn_hyperparameters/nd_to_1d_regression_direct.jl
@@ -1,0 +1,423 @@
+# Example to learn hyperparameters of simple nd-1d regression example.
+# This example matches test/Methods/runtests.jl testset: "Fit and predict: ND -> 1D"
+# The (approximate) optimal values here are used in those tests.
+
+
+using StableRNGs
+using Distributions
+using JLD2
+using StatsBase
+using LinearAlgebra
+using Random
+using Dates
+
+PLOT_FLAG = true
+println("plot flag:", PLOT_FLAG)
+if PLOT_FLAG
+    using Plots
+end
+using EnsembleKalmanProcesses
+using EnsembleKalmanProcesses.Localizers
+const EKP = EnsembleKalmanProcesses
+
+using RandomFeatures.ParameterDistributions
+using RandomFeatures.DataContainers
+using RandomFeatures.Samplers
+using RandomFeatures.Features
+using RandomFeatures.Methods
+using RandomFeatures.Utilities
+
+seed = 2024
+rng = StableRNG(seed)
+
+## Functions of use
+function RFM_from_hyperparameters(
+    rng::AbstractRNG,
+    l::Union{Real, AbstractVecOrMat},
+    regularizer::Real,
+    n_features::Int,
+    batch_sizes::Dict,
+    input_dim::Int,
+)
+
+    μ_c = 0.0
+    if isa(l, Real)
+        σ_c = fill(l, input_dim)
+    elseif isa(l, AbstractVector)
+        if length(l) == 1
+            σ_c = fill(l[1], input_dim)
+        else
+            σ_c = l
+        end
+    else
+        isa(l, AbstractMatrix)
+        σ_c = l[:, 1]
+    end
+
+    pd = ParameterDistribution(
+        Dict(
+            "distribution" => VectorOfParameterized(map(sd -> Normal(μ_c, sd), σ_c)),
+            "constraint" => repeat([no_constraint()], input_dim),
+            "name" => "xi",
+        ),
+    )
+    feature_sampler = FeatureSampler(pd, rng = rng)
+    # Learn hyperparameters for different feature types
+
+    sf = ScalarFourierFeature(n_features, feature_sampler)
+    return RandomFeatureMethod(sf, batch_sizes = batch_sizes, regularization = regularizer)
+end
+
+
+function calculate_mean_and_coeffs(
+    rng::AbstractRNG,
+    l::Union{Real, AbstractVecOrMat},
+    noise_sd::Real,
+    n_features::Int,
+    batch_sizes::Dict,
+    io_pairs::PairedDataContainer,
+)
+
+    regularizer = noise_sd^2
+    n_train = Int(floor(0.8 * size(get_inputs(io_pairs), 2))) # 80:20 train test
+    n_test = size(get_inputs(io_pairs), 2) - n_train
+
+    # split data into train/test randomly
+    itrain = get_inputs(io_pairs)[:, 1:n_train]
+    otrain = get_outputs(io_pairs)[:, 1:n_train]
+    io_train_cost = PairedDataContainer(itrain, otrain)
+    itest = get_inputs(io_pairs)[:, (n_train + 1):end]
+    otest = get_outputs(io_pairs)[:, (n_train + 1):end]
+    input_dim = size(itrain, 1)
+
+    # build and fit the RF
+    rfm = RFM_from_hyperparameters(rng, l, regularizer, n_features, batch_sizes, input_dim)
+    fitted_features = fit(rfm, io_train_cost)
+
+    test_batch_size = get_batch_size(rfm, "test")
+    batch_inputs = batch_generator(itest, test_batch_size, dims = 2) # input_dim x batch_size
+
+    #we want to calc 1/var(y-mean)^2 + lambda/m * coeffs^2 in the end
+    pred_mean, features = predictive_mean(rfm, fitted_features, DataContainer(itest))
+    scaled_coeffs = sqrt(1 / n_features) * get_coeffs(fitted_features)
+
+    chol_fac = get_decomposition(get_feature_factors(fitted_features)).L
+    complexity = 2 * sum(log(chol_fac[i, i]) for i in 1:size(chol_fac, 1))
+    complexity = sqrt(complexity)
+    return pred_mean, scaled_coeffs, complexity
+
+end
+
+
+function estimate_mean_and_coeffnorm_covariance(
+    rng::AbstractRNG,
+    l::Union{Real, AbstractVecOrMat},
+    noise_sd::Real,
+    n_features::Int,
+    batch_sizes::Dict,
+    io_pairs::PairedDataContainer,
+    n_samples::Int;
+    repeats::Int = 1,
+)
+    n_train = Int(floor(0.8 * size(get_inputs(io_pairs), 2))) # 80:20 train test
+    n_test = size(get_inputs(io_pairs), 2) - n_train
+    means = zeros(n_test, n_samples)
+    coeffl2norm = zeros(1, n_samples)
+    complexity = zeros(1, n_samples)
+    for i in 1:n_samples
+        for j in 1:repeats
+            m, c, cplxty = calculate_mean_and_coeffs(rng, l, noise_sd, n_features, batch_sizes, io_pairs)
+            means[:, i] += m[1, :] / repeats
+            coeffl2norm[1, i] += sqrt(sum(c .^ 2)) / repeats
+            complexity[1, i] += cplxty / repeats
+        end
+    end
+    Γ = cov(vcat(means, coeffl2norm, complexity), dims = 2)
+    return Γ
+
+end
+
+function calculate_ensemble_mean_and_coeffnorm(
+    rng::AbstractRNG,
+    lvecormat::AbstractVecOrMat,
+    noise_sd::Real,
+    n_features::Int,
+    batch_sizes::Dict,
+    io_pairs::PairedDataContainer;
+    repeats::Int = 1,
+)
+    if isa(lvecormat, AbstractVector)
+        lmat = reshape(lvecormat, 1, :)
+    else
+        lmat = lvecormat
+    end
+    N_ens = size(lmat, 2)
+    n_train = Int(floor(0.8 * size(get_inputs(io_pairs), 2))) # 80:20 train test
+    n_test = size(get_inputs(io_pairs), 2) - n_train
+
+    means = zeros(n_test, N_ens)
+    coeffl2norm = zeros(1, N_ens)
+    complexity = zeros(1, N_ens)
+    for i in collect(1:N_ens)
+        for j in collect(1:repeats)
+            l = lmat[:, i]
+            m, c, cplxty = calculate_mean_and_coeffs(rng, l, noise_sd, n_features, batch_sizes, io_pairs)
+            means[:, i] += m[1, :] / repeats
+            coeffl2norm[1, i] += sqrt(sum(c .^ 2)) / repeats
+            complexity[1, i] += cplxty / repeats
+        end
+    end
+    return vcat(means, coeffl2norm, complexity)
+
+end
+
+## Begin Script, define problem setting
+println("Begin script")
+date_of_run = Date(2024, 10, 4)
+input_dim = 6
+println("Number of input dimensions: ", input_dim)
+
+# not radial - different scale in each dimension
+ftest_nd_to_1d(x::AbstractMatrix) =
+    mapslices(column -> exp(-0.1 * norm([i * c for (i, c) in enumerate(column)])^2), x, dims = 1)
+n_data = 100 * input_dim
+x = rand(rng, MvNormal(zeros(input_dim), 0.5 * I), n_data)
+noise_sd = 1e-3
+noise = rand(rng, Normal(0, noise_sd), (1, n_data))
+regularizer = noise_sd^2
+
+y = ftest_nd_to_1d(x) + noise
+io_pairs = PairedDataContainer(x, y)
+
+## Define Hyperpriors for EKP
+
+μ_l = 5.0
+σ_l = 5.0
+
+# prior for non radial problem
+prior_lengthscale = constrained_gaussian("lengthscale", μ_l, σ_l, 0.0, Inf, repeats = input_dim)
+priors = prior_lengthscale
+
+# estimate the noise from running many RFM sample costs at the mean values
+batch_sizes = Dict("train" => 600, "test" => 600, "feature" => 600)
+n_features = Int(floor(0.5 * n_data))
+n_train = Int(floor(0.8 * n_data))
+n_test = n_data - n_train
+repeats = 3
+
+CALC_TRUTH = true
+
+println("RHKS norm type: norm of coefficients")
+
+if CALC_TRUTH
+    sample_multiplier = 1
+
+    n_samples = Int(floor(((1 + n_test) + 1) * sample_multiplier))
+    println("Estimating output covariance with ", n_samples, " samples")
+    internal_Γ = estimate_mean_and_coeffnorm_covariance(
+        rng,
+        μ_l, # take mean values
+        noise_sd,
+        n_features,
+        batch_sizes,
+        io_pairs,
+        n_samples,
+        repeats = repeats,
+    )
+
+
+    save("calculated_truth_cov.jld2", "internal_Γ", internal_Γ)
+else
+    println("Loading truth covariance from file...")
+    internal_Γ = load("calculated_truth_cov.jld2")["internal_Γ"]
+end
+
+Γ = internal_Γ
+Γ[1:n_test, 1:n_test] += regularizer * I
+Γ[(n_test + 1):end, (n_test + 1):end] += I
+
+println(
+    "Estimated covariance. Tr(cov) = ",
+    tr(Γ[1:n_test, 1:n_test]),
+    " + ",
+    Γ[n_test + 1, n_test + 1],
+    " + ",
+    Γ[n_test + 2, n_test + 2],
+)
+#println("noise in observations: ", Γ)
+# Create EKI
+N_ens = 10 * input_dim
+N_iter = 50 # 30
+update_cov_step = Inf
+
+initial_params = construct_initial_ensemble(rng, priors, N_ens)
+data = vcat(y[(n_train + 1):end], 0.0, 0.0)
+
+ekiobj = [
+    EKP.EnsembleKalmanProcess(
+        initial_params,
+        data,
+        Γ,
+        Inversion(),
+        localization_method = SECNice(),
+        scheduler = DataMisfitController(terminate_at = 1e4),
+        verbose = true,
+    ),
+]
+err = zeros(N_iter)
+println("Begin EKI iterations:")
+
+
+for i in 1:N_iter
+
+    #get parameters:
+    lvec = transform_unconstrained_to_constrained(priors, get_u_final(ekiobj[1]))
+    g_ens = calculate_ensemble_mean_and_coeffnorm(
+        rng,
+        lvec,
+        noise_sd,
+        n_features,
+        batch_sizes,
+        io_pairs,
+        repeats = repeats,
+    )
+
+    if i % update_cov_step == 0 # one update to the 
+
+        constrained_u = transform_unconstrained_to_constrained(priors, get_u_final(ekiobj[1]))
+        println("Estimating output covariance with ", n_samples, " samples")
+        internal_Γ_new = estimate_mean_and_coeffnorm_covariance(
+            rng,
+            mean(constrained_u, dims = 2)[:, 1], # take mean values
+            noise_sd,
+            n_features,
+            batch_sizes,
+            io_pairs,
+            n_samples,
+            repeats = repeats,
+        )
+        Γ_new = internal_Γ_new
+        Γ_new[1:n_test, 1:n_test] += regularizer * I
+        Γ_new[(n_test + 1):end, (n_test + 1):end] += I
+        println(
+            "Estimated covariance. Tr(cov) = ",
+            tr(Γ_new[1:n_test, 1:n_test]),
+            " + ",
+            tr(Γ_new[(n_test + 1):end, (n_test + 1):end]),
+        )
+
+        ekiobj[1] = EKP.EnsembleKalmanProcess(
+            get_u_final(ekiobj[1]),
+            data,
+            Γ_new,
+            Inversion(),
+            localization_method = loc_method,
+        )
+
+    end
+
+    terminated = EKP.update_ensemble!(ekiobj[1], g_ens)
+    if !isnothing(terminated)
+        break
+    end
+
+    err[i] = get_error(ekiobj[1])[end] #mean((params_true - mean(params_i,dims=2)).^2)
+    constrained_u = transform_unconstrained_to_constrained(priors, get_u_final(ekiobj[1]))
+    println(
+        "Iteration: " *
+        string(i) *
+        ", Error: " *
+        string(err[i]) *
+        ", for parameter means: " *
+        string(mean(constrained_u, dims = 2)),
+        " and sd :" * string(sqrt.(var(constrained_u, dims = 2))),
+    )
+end
+
+#run actual experiment
+# override following parameters for actual run
+n_data_test = 200 * input_dim
+n_features_test = Int(floor(1.2 * n_data_test))
+println("number of training data: ", n_data_test)
+println("number of features: ", n_features_test)
+#x_test = hcat(rand(rng, Uniform(-0.5,0.5), (input_dim, Int(floor(n_data_test/4)))),rand(rng, Uniform(-3,3), (input_dim, Int(n_data_test - floor(n_data_test/4)))))
+#x_test = x_test[:,shuffle(1:size(x_test,2))]
+x_test = rand(rng, MvNormal(zeros(input_dim), 0.5 * I), n_data_test)
+noise_test = rand(rng, Normal(0, noise_sd), (1, n_data_test))
+
+y_test = ftest_nd_to_1d(x_test) + noise_test
+io_pairs_test = PairedDataContainer(x_test, y_test)
+
+# get feature distribution
+final_lvec = mean(transform_unconstrained_to_constrained(priors, get_u_final(ekiobj[1])), dims = 2)
+
+μ_c = 0.0
+if size(final_lvec, 1) == 1
+    σ_c = repeat([final_lvec[1, 1]], input_dim)
+else
+    σ_c = final_lvec[:, 1]
+end
+pd = ParameterDistribution(
+    Dict(
+        "distribution" => VectorOfParameterized(map(sd -> Normal(μ_c, sd), σ_c)),
+        "constraint" => repeat([no_constraint()], input_dim),
+        "name" => "xi",
+    ),
+)
+feature_sampler = FeatureSampler(pd, rng = copy(rng))
+sff = ScalarFourierFeature(n_features_test, feature_sampler)
+
+#second case with batching
+
+rfm_batch = RandomFeatureMethod(sff, batch_sizes = batch_sizes, regularization = regularizer)
+fitted_batched_features = fit(rfm_batch, io_pairs_test)
+
+if PLOT_FLAG
+    #plot slice through one dimensions, others fixed to 0
+    xrange = collect(-3:0.01:3)
+    xslice = zeros(input_dim, length(xrange))
+    figure_save_directory = joinpath(@__DIR__, "output", string(date_of_run))
+    if !isdir(figure_save_directory)
+        mkpath(figure_save_directory)
+    end
+
+    for direction in 1:input_dim
+        xslicenew = copy(xslice)
+        xslicenew[direction, :] = xrange
+
+        yslice = ftest_nd_to_1d(xslicenew)
+        pred_mean_slice, pred_cov_slice = predict(rfm_batch, fitted_batched_features, DataContainer(xslicenew))
+        pred_cov_slice = max.(pred_cov_slice[1, 1, :], 0.0)
+        plt = plot(
+            xrange,
+            yslice',
+            show = false,
+            color = "black",
+            linewidth = 5,
+            size = (600, 600),
+            legend = :topleft,
+            label = "Target",
+        )
+        plot!(
+            xrange,
+            pred_mean_slice',
+            ribbon = [2 * sqrt.(pred_cov_slice); 2 * sqrt.(pred_cov_slice)]',
+            label = "Fourier",
+            color = "blue",
+        )
+        savefig(
+            plt,
+            joinpath(
+                figure_save_directory,
+                "Fit_and_predict_ND_" * string(direction) * "of" * string(input_dim) * ".pdf",
+            ),
+        )
+        savefig(
+            plt,
+            joinpath(
+                figure_save_directory,
+                "Fit_and_predict_ND_" * string(direction) * "of" * string(input_dim) * ".png",
+            ),
+        )
+    end
+end

--- a/examples/Learn_hyperparameters/nd_to_1d_regression_direct_crossval.jl
+++ b/examples/Learn_hyperparameters/nd_to_1d_regression_direct_crossval.jl
@@ -1,5 +1,5 @@
-# Example to learn hyperparameters of simple 1d-1d regression example.
-# This example matches test/Methods/runtests.jl testset: "Fit and predict: 1D -> 1D"
+# Example to learn hyperparameters of simple nd-1d regression example.
+# This example matches test/Methods/runtests.jl testset: "Fit and predict: ND -> 1D"
 # The (approximate) optimal values here are used in those tests.
 
 
@@ -69,26 +69,27 @@ function RFM_from_hyperparameters(
 end
 
 
-function calculate_mean_cov_and_coeffs(
+function calculate_mean_and_coeffs(
     rng::AbstractRNG,
     l::Union{Real, AbstractVecOrMat},
     noise_sd::Real,
     n_features::Int,
+    train_idx,
+    test_idx,        
     batch_sizes::Dict,
     io_pairs::PairedDataContainer,
 )
 
     regularizer = noise_sd^2
-    n_train = Int(floor(0.8 * size(get_inputs(io_pairs), 2))) # 80:20 train test
-    n_test = size(get_inputs(io_pairs), 2) - n_train
 
-    # split data into train/test randomly
-    itrain = get_inputs(io_pairs)[:, 1:n_train]
-    otrain = get_outputs(io_pairs)[:, 1:n_train]
+    itrain = get_inputs(io_pairs)[:, train_idx]
+    otrain = get_outputs(io_pairs)[:, train_idx]
     io_train_cost = PairedDataContainer(itrain, otrain)
-    itest = get_inputs(io_pairs)[:, (n_train + 1):end]
-    otest = get_outputs(io_pairs)[:, (n_train + 1):end]
+    itest = get_inputs(io_pairs)[:, test_idx]
+    otest = get_outputs(io_pairs)[:, test_idx]
     input_dim = size(itrain, 1)
+    output_dim = size(otrain, 1)
+    n_test = size(itest, 2)
 
     # build and fit the RF
     rfm = RFM_from_hyperparameters(rng, l, regularizer, n_features, batch_sizes, input_dim)
@@ -98,54 +99,53 @@ function calculate_mean_cov_and_coeffs(
     batch_inputs = batch_generator(itest, test_batch_size, dims = 2) # input_dim x batch_size
 
     #we want to calc 1/var(y-mean)^2 + lambda/m * coeffs^2 in the end
-    pred_mean, pred_cov = predict(rfm, fitted_features, DataContainer(itest))
+    pred_mean, features = predictive_mean(rfm, fitted_features, DataContainer(itest))
     scaled_coeffs = sqrt(1 / n_features) * get_coeffs(fitted_features)
 
     chol_fac = get_decomposition(get_feature_factors(fitted_features)).L
     complexity = 2 * sum(log(chol_fac[i, i]) for i in 1:size(chol_fac, 1))
     complexity = sqrt(complexity)
-    return pred_mean, pred_cov, scaled_coeffs, complexity
+    return pred_mean, scaled_coeffs, complexity
 
 end
 
 
-function estimate_mean_cov_and_coeffnorm_covariance(
+function estimate_mean_and_coeffnorm_covariance(
     rng::AbstractRNG,
     l::Union{Real, AbstractVecOrMat},
     noise_sd::Real,
     n_features::Int,
+    train_idx,
+    test_idx,        
     batch_sizes::Dict,
     io_pairs::PairedDataContainer,
     n_samples::Int;
     repeats::Int = 1,
 )
-    n_train = Int(floor(0.8 * size(get_inputs(io_pairs), 2))) # 80:20 train test
-    n_test = size(get_inputs(io_pairs), 2) - n_train
+    n_test = length(test_idx)
     means = zeros(n_test, n_samples)
-    covs = zeros(n_test, n_samples)
     coeffl2norm = zeros(1, n_samples)
     complexity = zeros(1, n_samples)
     for i in 1:n_samples
         for j in 1:repeats
-            m, v, c, cplxty = calculate_mean_cov_and_coeffs(rng, l, noise_sd, n_features, batch_sizes, io_pairs)
+            m, c, cplxty = calculate_mean_and_coeffs(rng, l, noise_sd, n_features, train_idx, test_idx, batch_sizes, io_pairs)
             means[:, i] += m[1, :] / repeats
-            covs[:, i] += v[1, 1, :] / repeats
             coeffl2norm[1, i] += sqrt(sum(c .^ 2)) / repeats
             complexity[1, i] += cplxty / repeats
         end
     end
     Γ = cov(vcat(means, coeffl2norm, complexity), dims = 2)
-    approx_σ = Diagonal(mean(covs, dims = 2)[:, 1]) # approx of \sigma^2I +rf var
-
-    return Γ, approx_σ
+    return Γ
 
 end
 
-function calculate_ensemble_mean_cov_and_coeffnorm(
+function calculate_ensemble_mean_and_coeffnorm(
     rng::AbstractRNG,
     lvecormat::AbstractVecOrMat,
     noise_sd::Real,
     n_features::Int,
+    train_idx,
+    test_idx,   
     batch_sizes::Dict,
     io_pairs::PairedDataContainer;
     repeats::Int = 1,
@@ -156,30 +156,26 @@ function calculate_ensemble_mean_cov_and_coeffnorm(
         lmat = lvecormat
     end
     N_ens = size(lmat, 2)
-    n_train = Int(floor(0.8 * size(get_inputs(io_pairs), 2))) # 80:20 train test
-    n_test = size(get_inputs(io_pairs), 2) - n_train
-
+    n_test = length(test_idx)
     means = zeros(n_test, N_ens)
-    covs = zeros(n_test, N_ens)
     coeffl2norm = zeros(1, N_ens)
     complexity = zeros(1, N_ens)
     for i in collect(1:N_ens)
         for j in collect(1:repeats)
             l = lmat[:, i]
-            m, v, c, cplxty = calculate_mean_cov_and_coeffs(rng, l, noise_sd, n_features, batch_sizes, io_pairs)
+            m, c, cplxty = calculate_mean_and_coeffs(rng, l, noise_sd, n_features, train_idx, test_idx, batch_sizes, io_pairs)
             means[:, i] += m[1, :] / repeats
-            covs[:, i] += v[1, 1, :] / repeats
             coeffl2norm[1, i] += sqrt(sum(c .^ 2)) / repeats
             complexity[1, i] += cplxty / repeats
         end
     end
-    return vcat(means, coeffl2norm, complexity), Diagonal(mean(covs, dims = 2)[:, 1]) # approx of +\sigma^2I
+    return vcat(means, coeffl2norm, complexity)
 
 end
 
 ## Begin Script, define problem setting
 println("Begin script")
-date_of_run = Date(2024, 5, 16)
+date_of_run = Date(2024, 10, 4)
 input_dim = 6
 println("Number of input dimensions: ", input_dim)
 
@@ -209,7 +205,20 @@ batch_sizes = Dict("train" => 600, "test" => 600, "feature" => 600)
 n_features = Int(floor(0.5 * n_data))
 n_train = Int(floor(0.8 * n_data))
 n_test = n_data - n_train
-repeats = 1
+n_cross_val = 3
+@info "number of cross-validation sets: $(n_cross_val)"
+if n_test*n_cross_val > n_data
+    throw(ArgumentError("train/test split produces cross validation test sets of size $(n_test), out of $(n_data). set \"n_cross_val\" < $(Int(floor(n_data/n_test))). Received $n_cross_val"))
+end
+train_idx = []
+test_idx = []
+idx_shuffle = randperm(rng, n_data)
+for i = 1:n_cross_val
+    tmp = idx_shuffle[(i-1)*n_test+1:i*n_test]
+    push!(test_idx, tmp)
+    push!(train_idx, setdiff(collect(1:n_data), tmp))
+end
+
 
 CALC_TRUTH = true
 
@@ -217,54 +226,57 @@ println("RHKS norm type: norm of coefficients")
 
 if CALC_TRUTH
     sample_multiplier = 1
-
     n_samples = Int(floor(((1 + n_test) + 1) * sample_multiplier))
-    println("Estimating output covariance with ", n_samples, " samples")
-    internal_Γ, approx_σ = estimate_mean_cov_and_coeffnorm_covariance(
-        rng,
-        μ_l, # take mean values
-        noise_sd,
-        n_features,
-        batch_sizes,
-        io_pairs,
-        n_samples,
-        repeats = repeats,
-    )
 
+    observation_vec = []
+    for cv_idx = 1:n_cross_val
+        println("Estimating output covariance with ", n_samples, " samples")
+        internal_Γ = estimate_mean_and_coeffnorm_covariance(
+            rng,
+            μ_l, # take mean values
+            noise_sd,
+            n_features,
+            train_idx[cv_idx],
+            test_idx[cv_idx],
+            batch_sizes,
+            io_pairs,
+            n_samples,
+        )
 
-    save("calculated_truth_cov.jld2", "internal_Γ", internal_Γ, "approx_σ", approx_σ)
+        Γ = internal_Γ
+        Γ[1:n_test, 1:n_test] += regularizer * I
+        Γ[(n_test + 1):end, (n_test + 1):end] += I
+
+        data = vcat(get_outputs(io_pairs)[test_idx[cv_idx]], 0.0, 0.0)
+
+        push!(observation_vec, EKP.Observation(
+            Dict(
+                "names" => "$(cv_idx)",
+                "samples" => data[:],
+                "covariances" => Γ,
+            ),
+        ),
+              )
+    end
+    observation = combine_observations(observation_vec)
+
+    save("calculated_truth_cov.jld2", "observation", observation)
 else
     println("Loading truth covariance from file...")
-    internal_Γ = load("calculated_truth_cov.jld2")["internal_Γ"]
-    approx_σ = load("calculated_truth_cov.jld2")["approx_σ"]
+    internal_Γ = load("calculated_truth_cov.jld2")["observation"]
 end
 
-Γ = internal_Γ
-Γ[1:n_test, 1:n_test] += regularizer * I
-Γ[(n_test + 1):end, (n_test + 1):end] += I
-
-println(
-    "Estimated covariance. Tr(cov) = ",
-    tr(Γ[1:n_test, 1:n_test]),
-    " + ",
-    Γ[n_test + 1, n_test + 1],
-    " + ",
-    Γ[n_test + 2, n_test + 2],
-)
-#println("noise in observations: ", Γ)
 # Create EKI
 N_ens = 10 * input_dim
-N_iter = 50 # 30
+N_iter = 20 # 30
 update_cov_step = Inf
 
 initial_params = construct_initial_ensemble(rng, priors, N_ens)
-data = vcat(y[(n_train + 1):end], 0.0, 0.0)
 
 ekiobj = [
     EKP.EnsembleKalmanProcess(
         initial_params,
-        data,
-        Γ,
+        observation,
         Inversion(),
         localization_method = SECNice(),
         scheduler = DataMisfitController(terminate_at = 1e4),
@@ -279,21 +291,28 @@ for i in 1:N_iter
 
     #get parameters:
     lvec = transform_unconstrained_to_constrained(priors, get_u_final(ekiobj[1]))
-    g_ens, approx_σ_ens = calculate_ensemble_mean_cov_and_coeffnorm(
-        rng,
-        lvec,
-        noise_sd,
-        n_features,
-        batch_sizes,
-        io_pairs,
-        repeats = repeats,
-    )
 
+    g_ens = zeros(n_cross_val*(n_test+2),N_ens)
+    for cv_idx = 1:n_cross_val
+        g_ens_tmp = calculate_ensemble_mean_and_coeffnorm(
+            rng,
+            lvec,
+            noise_sd,
+            n_features,
+            train_idx[cv_idx],
+            test_idx[cv_idx],
+            batch_sizes,
+            io_pairs,
+        )
+        g_ens[(cv_idx-1)*(n_test+2) + 1: cv_idx*(n_test+2), :] = g_ens_tmp
+    end
+          
+#=    
     if i % update_cov_step == 0 # one update to the 
 
         constrained_u = transform_unconstrained_to_constrained(priors, get_u_final(ekiobj[1]))
         println("Estimating output covariance with ", n_samples, " samples")
-        internal_Γ_new, approx_σ_new = estimate_mean_cov_and_coeffnorm_covariance(
+        internal_Γ_new = estimate_mean_and_coeffnorm_covariance(
             rng,
             mean(constrained_u, dims = 2)[:, 1], # take mean values
             noise_sd,
@@ -301,7 +320,6 @@ for i in 1:N_iter
             batch_sizes,
             io_pairs,
             n_samples,
-            repeats = repeats,
         )
         Γ_new = internal_Γ_new
         Γ_new[1:n_test, 1:n_test] += regularizer * I
@@ -322,7 +340,7 @@ for i in 1:N_iter
         )
 
     end
-
+=#
     terminated = EKP.update_ensemble!(ekiobj[1], g_ens)
     if !isnothing(terminated)
         break
@@ -416,14 +434,14 @@ if PLOT_FLAG
             plt,
             joinpath(
                 figure_save_directory,
-                "Fit_and_predict_ND_" * string(direction) * "of" * string(input_dim) * ".pdf",
+                "Fit_and_predict_ND_crossval$(n_cross_val)_" * string(direction) * "of" * string(input_dim) * ".pdf",
             ),
         )
         savefig(
             plt,
             joinpath(
                 figure_save_directory,
-                "Fit_and_predict_ND_" * string(direction) * "of" * string(input_dim) * ".png",
+                "Fit_and_predict_ND_crossval$(n_cross_val)_" * string(direction) * "of" * string(input_dim) * ".png",
             ),
         )
     end

--- a/examples/Learn_hyperparameters/nd_to_1d_regression_direct_nodatasplit.jl
+++ b/examples/Learn_hyperparameters/nd_to_1d_regression_direct_nodatasplit.jl
@@ -1,0 +1,416 @@
+# Example to learn hyperparameters of simple nd-1d regression example.
+# This example matches test/Methods/runtests.jl testset: "Fit and predict: ND -> 1D"
+# The (approximate) optimal values here are used in those tests.
+
+
+using StableRNGs
+using Distributions
+using JLD2
+using StatsBase
+using LinearAlgebra
+using Random
+using Dates
+
+PLOT_FLAG = true
+println("plot flag:", PLOT_FLAG)
+if PLOT_FLAG
+    using Plots
+end
+using EnsembleKalmanProcesses
+using EnsembleKalmanProcesses.Localizers
+const EKP = EnsembleKalmanProcesses
+
+using RandomFeatures.ParameterDistributions
+using RandomFeatures.DataContainers
+using RandomFeatures.Samplers
+using RandomFeatures.Features
+using RandomFeatures.Methods
+using RandomFeatures.Utilities
+
+seed = 2024
+rng = StableRNG(seed)
+
+## Functions of use
+function RFM_from_hyperparameters(
+    rng::AbstractRNG,
+    l::Union{Real, AbstractVecOrMat},
+    regularizer::Real,
+    n_features::Int,
+    batch_sizes::Dict,
+    input_dim::Int,
+)
+
+    μ_c = 0.0
+    if isa(l, Real)
+        σ_c = fill(l, input_dim)
+    elseif isa(l, AbstractVector)
+        if length(l) == 1
+            σ_c = fill(l[1], input_dim)
+        else
+            σ_c = l
+        end
+    else
+        isa(l, AbstractMatrix)
+        σ_c = l[:, 1]
+    end
+
+    pd = ParameterDistribution(
+        Dict(
+            "distribution" => VectorOfParameterized(map(sd -> Normal(μ_c, sd), σ_c)),
+            "constraint" => repeat([no_constraint()], input_dim),
+            "name" => "xi",
+        ),
+    )
+    feature_sampler = FeatureSampler(pd, rng = rng)
+    # Learn hyperparameters for different feature types
+
+    sf = ScalarFourierFeature(n_features, feature_sampler)
+    return RandomFeatureMethod(sf, batch_sizes = batch_sizes, regularization = regularizer)
+end
+
+
+function calculate_mean_and_coeffs(
+    rng::AbstractRNG,
+    l::Union{Real, AbstractVecOrMat},
+    noise_sd::Real,
+    n_features::Int,
+    batch_sizes::Dict,
+    io_pairs::PairedDataContainer,
+)
+
+    regularizer = noise_sd^2
+    n_data = size(get_inputs(io_pairs), 2)
+
+    # split data into train/test randomly
+    itrain = get_inputs(io_pairs)
+    otrain = get_outputs(io_pairs)
+    io_train_cost = PairedDataContainer(itrain, otrain)
+    input_dim = size(itrain, 1)
+
+    # build and fit the RF
+    rfm = RFM_from_hyperparameters(rng, l, regularizer, n_features, batch_sizes, input_dim)
+    fitted_features = fit(rfm, io_train_cost)
+
+    test_batch_size = get_batch_size(rfm, "test")
+    batch_inputs = batch_generator(itrain, test_batch_size, dims = 2) # input_dim x batch_size
+
+    #we want to calc 1/var(y-mean)^2 + lambda/m * coeffs^2 in the end
+    pred_mean, features = predictive_mean(rfm, fitted_features, DataContainer(itrain))
+    scaled_coeffs = sqrt(1 / n_features) * get_coeffs(fitted_features)
+
+    chol_fac = get_decomposition(get_feature_factors(fitted_features)).L
+    complexity = 2 * sum(log(chol_fac[i, i]) for i in 1:size(chol_fac, 1))
+    complexity = sqrt(complexity)
+    return pred_mean, scaled_coeffs, complexity
+
+end
+
+
+function estimate_mean_and_coeffnorm_covariance(
+    rng::AbstractRNG,
+    l::Union{Real, AbstractVecOrMat},
+    noise_sd::Real,
+    n_features::Int,
+    batch_sizes::Dict,
+    io_pairs::PairedDataContainer,
+    n_samples::Int;
+    repeats::Int = 1,
+)
+    n_data = size(get_inputs(io_pairs), 2)
+    means = zeros(n_data, n_samples)
+    coeffl2norm = zeros(1, n_samples)
+    complexity = zeros(1, n_samples)
+    for i in 1:n_samples
+        for j in 1:repeats
+            m, c, cplxty = calculate_mean_and_coeffs(rng, l, noise_sd, n_features, batch_sizes, io_pairs)
+            means[:, i] += m[1, :] / repeats
+            coeffl2norm[1, i] += sqrt(sum(c .^ 2)) / repeats
+            complexity[1, i] += cplxty / repeats
+        end
+    end
+    Γ = cov(vcat(means, coeffl2norm, complexity), dims = 2)
+    return Γ
+
+end
+
+function calculate_ensemble_mean_and_coeffnorm(
+    rng::AbstractRNG,
+    lvecormat::AbstractVecOrMat,
+    noise_sd::Real,
+    n_features::Int,
+    batch_sizes::Dict,
+    io_pairs::PairedDataContainer;
+    repeats::Int = 1,
+)
+    if isa(lvecormat, AbstractVector)
+        lmat = reshape(lvecormat, 1, :)
+    else
+        lmat = lvecormat
+    end
+    N_ens = size(lmat, 2)
+    n_data = size(get_inputs(io_pairs), 2)
+
+    means = zeros(n_data, N_ens)
+    coeffl2norm = zeros(1, N_ens)
+    complexity = zeros(1, N_ens)
+    for i in collect(1:N_ens)
+        for j in collect(1:repeats)
+            l = lmat[:, i]
+            m, c, cplxty = calculate_mean_and_coeffs(rng, l, noise_sd, n_features, batch_sizes, io_pairs)
+            means[:, i] += m[1, :] / repeats
+            coeffl2norm[1, i] += sqrt(sum(c .^ 2)) / repeats
+            complexity[1, i] += cplxty / repeats
+        end
+    end
+    return vcat(means, coeffl2norm, complexity)
+
+end
+
+## Begin Script, define problem setting
+println("Begin script")
+date_of_run = Date(2024, 10, 4)
+input_dim = 6
+println("Number of input dimensions: ", input_dim)
+
+# not radial - different scale in each dimension
+ftest_nd_to_1d(x::AbstractMatrix) =
+    mapslices(column -> exp(-0.1 * norm([i * c for (i, c) in enumerate(column)])^2), x, dims = 1)
+n_data = 100 * input_dim
+x = rand(rng, MvNormal(zeros(input_dim), 0.5 * I), n_data)
+noise_sd = 1e-3
+noise = rand(rng, Normal(0, noise_sd), (1, n_data))
+regularizer = noise_sd^2
+
+y = ftest_nd_to_1d(x) + noise
+io_pairs = PairedDataContainer(x, y)
+
+## Define Hyperpriors for EKP
+
+μ_l = 5.0
+σ_l = 5.0
+
+# prior for non radial problem
+prior_lengthscale = constrained_gaussian("lengthscale", μ_l, σ_l, 0.0, Inf, repeats = input_dim)
+priors = prior_lengthscale
+
+# estimate the noise from running many RFM sample costs at the mean values
+batch_sizes = Dict("train" => 600, "test" => 600, "feature" => 600)
+n_features = Int(floor(0.5 * n_data))
+repeats = 1
+
+CALC_TRUTH = true
+
+println("RHKS norm type: norm of coefficients")
+
+if CALC_TRUTH
+    sample_multiplier = 1
+
+    n_samples = Int(floor(((1 + n_data) + 1) * sample_multiplier))
+    println("Estimating output covariance with ", n_samples, " samples")
+    internal_Γ = estimate_mean_and_coeffnorm_covariance(
+        rng,
+        μ_l, # take mean values
+        noise_sd,
+        n_features,
+        batch_sizes,
+        io_pairs,
+        n_samples,
+        repeats = repeats,
+    )
+
+
+    save("calculated_truth_cov.jld2", "internal_Γ", internal_Γ)
+else
+    println("Loading truth covariance from file...")
+    internal_Γ = load("calculated_truth_cov.jld2")["internal_Γ"]
+end
+
+Γ = internal_Γ
+Γ[1:n_data, 1:n_data] += regularizer * I
+Γ[(n_data + 1):end, (n_data + 1):end] += I
+
+println(
+    "Estimated covariance. Tr(cov) = ",
+    tr(Γ[1:n_data, 1:n_data]),
+    " + ",
+    Γ[n_data + 1, n_data + 1],
+    " + ",
+    Γ[n_data + 2, n_data + 2],
+)
+#println("noise in observations: ", Γ)
+# Create EKI
+N_ens = 10 * input_dim
+N_iter = 50 # 30
+update_cov_step = Inf
+
+initial_params = construct_initial_ensemble(rng, priors, N_ens)
+data = vcat(y[:], 0.0, 0.0)
+
+ekiobj = [
+    EKP.EnsembleKalmanProcess(
+        initial_params,
+        data,
+        Γ,
+        Inversion(),
+        localization_method = SECNice(),
+        scheduler = DataMisfitController(terminate_at = 1e4),
+        verbose = true,
+    ),
+]
+err = zeros(N_iter)
+println("Begin EKI iterations:")
+
+
+for i in 1:N_iter
+
+    #get parameters:
+    lvec = transform_unconstrained_to_constrained(priors, get_u_final(ekiobj[1]))
+    g_ens = calculate_ensemble_mean_and_coeffnorm(
+        rng,
+        lvec,
+        noise_sd,
+        n_features,
+        batch_sizes,
+        io_pairs,
+        repeats = repeats,
+    )
+
+    if i % update_cov_step == 0 # one update to the 
+
+        constrained_u = transform_unconstrained_to_constrained(priors, get_u_final(ekiobj[1]))
+        println("Estimating output covariance with ", n_samples, " samples")
+        internal_Γ_new = estimate_mean_and_coeffnorm_covariance(
+            rng,
+            mean(constrained_u, dims = 2)[:, 1], # take mean values
+            noise_sd,
+            n_features,
+            batch_sizes,
+            io_pairs,
+            n_samples,
+            repeats = repeats,
+        )
+        Γ_new = internal_Γ_new
+        Γ_new[1:n_data, 1:n_data] += regularizer * I
+        Γ_new[(n_data + 1):end, (n_data + 1):end] += I
+        println(
+            "Estimated covariance. Tr(cov) = ",
+            tr(Γ_new[1:n_data, 1:n_data]),
+            " + ",
+            tr(Γ_new[(n_data + 1):end, (n_data + 1):end]),
+        )
+
+        ekiobj[1] = EKP.EnsembleKalmanProcess(
+            get_u_final(ekiobj[1]),
+            data,
+            Γ_new,
+            Inversion(),
+            localization_method = loc_method,
+        )
+
+    end
+
+    terminated = EKP.update_ensemble!(ekiobj[1], g_ens)
+    if !isnothing(terminated)
+        break
+    end
+
+    err[i] = get_error(ekiobj[1])[end] #mean((params_true - mean(params_i,dims=2)).^2)
+    constrained_u = transform_unconstrained_to_constrained(priors, get_u_final(ekiobj[1]))
+    println(
+        "Iteration: " *
+        string(i) *
+        ", Error: " *
+        string(err[i]) *
+        ", for parameter means: " *
+        string(mean(constrained_u, dims = 2)),
+        " and sd :" * string(sqrt.(var(constrained_u, dims = 2))),
+    )
+end
+
+#run actual experiment
+# override following parameters for actual run
+n_data_test = 200 * input_dim
+n_features_test = Int(floor(1.2 * n_data_test))
+println("number of training data: ", n_data_test)
+println("number of features: ", n_features_test)
+#x_test = hcat(rand(rng, Uniform(-0.5,0.5), (input_dim, Int(floor(n_data_test/4)))),rand(rng, Uniform(-3,3), (input_dim, Int(n_data_test - floor(n_data_test/4)))))
+#x_test = x_test[:,shuffle(1:size(x_test,2))]
+x_test = rand(rng, MvNormal(zeros(input_dim), 0.5 * I), n_data_test)
+noise_test = rand(rng, Normal(0, noise_sd), (1, n_data_test))
+
+y_test = ftest_nd_to_1d(x_test) + noise_test
+io_pairs_test = PairedDataContainer(x_test, y_test)
+
+# get feature distribution
+final_lvec = mean(transform_unconstrained_to_constrained(priors, get_u_final(ekiobj[1])), dims = 2)
+
+μ_c = 0.0
+if size(final_lvec, 1) == 1
+    σ_c = repeat([final_lvec[1, 1]], input_dim)
+else
+    σ_c = final_lvec[:, 1]
+end
+pd = ParameterDistribution(
+    Dict(
+        "distribution" => VectorOfParameterized(map(sd -> Normal(μ_c, sd), σ_c)),
+        "constraint" => repeat([no_constraint()], input_dim),
+        "name" => "xi",
+    ),
+)
+feature_sampler = FeatureSampler(pd, rng = copy(rng))
+sff = ScalarFourierFeature(n_features_test, feature_sampler)
+
+#second case with batching
+
+rfm_batch = RandomFeatureMethod(sff, batch_sizes = batch_sizes, regularization = regularizer)
+fitted_batched_features = fit(rfm_batch, io_pairs_test)
+
+if PLOT_FLAG
+    #plot slice through one dimensions, others fixed to 0
+    xrange = collect(-3:0.01:3)
+    xslice = zeros(input_dim, length(xrange))
+    figure_save_directory = joinpath(@__DIR__, "output", string(date_of_run))
+    if !isdir(figure_save_directory)
+        mkpath(figure_save_directory)
+    end
+
+    for direction in 1:input_dim
+        xslicenew = copy(xslice)
+        xslicenew[direction, :] = xrange
+
+        yslice = ftest_nd_to_1d(xslicenew)
+        pred_mean_slice, pred_cov_slice = predict(rfm_batch, fitted_batched_features, DataContainer(xslicenew))
+        pred_cov_slice = max.(pred_cov_slice[1, 1, :], 0.0)
+        plt = plot(
+            xrange,
+            yslice',
+            show = false,
+            color = "black",
+            linewidth = 5,
+            size = (600, 600),
+            legend = :topleft,
+            label = "Target",
+        )
+        plot!(
+            xrange,
+            pred_mean_slice',
+            ribbon = [2 * sqrt.(pred_cov_slice); 2 * sqrt.(pred_cov_slice)]',
+            label = "Fourier",
+            color = "blue",
+        )
+        savefig(
+            plt,
+            joinpath(
+                figure_save_directory,
+                "Fit_and_predict_ND_nodatasplit_" * string(direction) * "of" * string(input_dim) * ".pdf",
+            ),
+        )
+        savefig(
+            plt,
+            joinpath(
+                figure_save_directory,
+                "Fit_and_predict_ND_nodatasplit_" * string(direction) * "of" * string(input_dim) * ".png",
+            ),
+        )
+    end
+end

--- a/examples/Learn_hyperparameters/nd_to_1d_regression_direct_nodatasplit.jl
+++ b/examples/Learn_hyperparameters/nd_to_1d_regression_direct_nodatasplit.jl
@@ -265,15 +265,8 @@ for i in 1:N_iter
 
     #get parameters:
     lvec = transform_unconstrained_to_constrained(priors, get_u_final(ekiobj[1]))
-    g_ens = calculate_ensemble_mean_and_coeffnorm(
-        rng,
-        lvec,
-        noise_sd,
-        n_features,
-        batch_sizes,
-        io_pairs,
-        repeats = repeats,
-    )
+    g_ens =
+        calculate_ensemble_mean_and_coeffnorm(rng, lvec, noise_sd, n_features, batch_sizes, io_pairs, repeats = repeats)
 
     if i % update_cov_step == 0 # one update to the 
 

--- a/examples/Learn_hyperparameters/nd_to_md_regression_direct_withcov.jl
+++ b/examples/Learn_hyperparameters/nd_to_md_regression_direct_withcov.jl
@@ -149,18 +149,31 @@ function calculate_mean_cov_and_coeffs(
     L <: Union{AbstractMatrix, UniformScaling, Real},
 }
 
-    n_train = Int(floor(0.8 * size(get_inputs(io_pairs), 2))) # 80:20 train test
-    n_test = size(get_inputs(io_pairs), 2) - n_train
+    data_split = true
+    if data_split
+        n_train = Int(floor(0.8 * size(get_inputs(io_pairs), 2))) # 80:20 train test
+        n_test = size(get_inputs(io_pairs), 2) - n_train
+        # split data into train/test randomly
+        itrain = get_inputs(io_pairs)[:, 1:n_train]
+        otrain = get_outputs(io_pairs)[:, 1:n_train]
+        io_train_cost = PairedDataContainer(itrain, otrain)
+        itest = get_inputs(io_pairs)[:, (n_train + 1):end]
+        otest = get_outputs(io_pairs)[:, (n_train + 1):end]
+        
+    else
+        
+        n_train = Int(size(get_inputs(io_pairs),2))
+        n_test = n_train
+        # split data into train/test randomly
+        itrain = get_inputs(io_pairs)[:, 1:n_train]
+        otrain = get_outputs(io_pairs)[:, 1:n_train]
+        io_train_cost = PairedDataContainer(itrain, otrain)
+        itest = itrain
+        otest = otrain
+    end
 
-    # split data into train/test randomly
-    itrain = get_inputs(io_pairs)[:, 1:n_train]
-    otrain = get_outputs(io_pairs)[:, 1:n_train]
-    io_train_cost = PairedDataContainer(itrain, otrain)
-    itest = get_inputs(io_pairs)[:, (n_train + 1):end]
-    otest = get_outputs(io_pairs)[:, (n_train + 1):end]
     input_dim = size(itrain, 1)
     output_dim = size(otrain, 1)
-
     # build and fit the RF
     rfm = RFM_from_hyperparameters(rng, l, lambda, n_features, batch_sizes, input_dim, output_dim)
     if decomp_type == "chol"
@@ -208,8 +221,14 @@ function estimate_mean_and_coeffnorm_covariance(
     RorM <: Union{Real, AbstractVecOrMat},
     L <: Union{AbstractMatrix, UniformScaling, Real},
 }
-    n_train = Int(floor(0.8 * size(get_inputs(io_pairs), 2))) # 80:20 train test
-    n_test = size(get_inputs(io_pairs), 2) - n_train
+    data_split = true
+    if data_split
+        n_train = Int(floor(0.8 * size(get_inputs(io_pairs), 2))) # 80:20 train test
+        n_test = size(get_inputs(io_pairs), 2) - n_train
+    else
+        n_train = Int( size(get_inputs(io_pairs), 2))
+        n_test = n_train
+    end
     output_dim = size(get_outputs(io_pairs), 1)
 
     means = zeros(output_dim, n_samples, n_test)
@@ -286,8 +305,15 @@ function calculate_ensemble_mean_and_coeffnorm(
         lmat = lvecormat
     end
     N_ens = size(lmat, 2)
-    n_train = Int(floor(0.8 * size(get_inputs(io_pairs), 2))) # 80:20 train test
-    n_test = size(get_inputs(io_pairs), 2) - n_train
+    data_split = true
+    if data_split
+        n_train = Int(floor(0.8 * size(get_inputs(io_pairs), 2))) # 80:20 train test
+        n_test = size(get_inputs(io_pairs), 2) - n_train
+    else
+        n_train = Int( size(get_inputs(io_pairs), 2))
+        n_test = n_train
+    end
+
     output_dim = size(get_outputs(io_pairs), 1)
 
     means = zeros(output_dim, N_ens, n_test)

--- a/examples/Learn_hyperparameters/nd_to_md_regression_direct_withcov.jl
+++ b/examples/Learn_hyperparameters/nd_to_md_regression_direct_withcov.jl
@@ -159,10 +159,10 @@ function calculate_mean_cov_and_coeffs(
         io_train_cost = PairedDataContainer(itrain, otrain)
         itest = get_inputs(io_pairs)[:, (n_train + 1):end]
         otest = get_outputs(io_pairs)[:, (n_train + 1):end]
-        
+
     else
-        
-        n_train = Int(size(get_inputs(io_pairs),2))
+
+        n_train = Int(size(get_inputs(io_pairs), 2))
         n_test = n_train
         # split data into train/test randomly
         itrain = get_inputs(io_pairs)[:, 1:n_train]
@@ -226,7 +226,7 @@ function estimate_mean_and_coeffnorm_covariance(
         n_train = Int(floor(0.8 * size(get_inputs(io_pairs), 2))) # 80:20 train test
         n_test = size(get_inputs(io_pairs), 2) - n_train
     else
-        n_train = Int( size(get_inputs(io_pairs), 2))
+        n_train = Int(size(get_inputs(io_pairs), 2))
         n_test = n_train
     end
     output_dim = size(get_outputs(io_pairs), 1)
@@ -310,7 +310,7 @@ function calculate_ensemble_mean_and_coeffnorm(
         n_train = Int(floor(0.8 * size(get_inputs(io_pairs), 2))) # 80:20 train test
         n_test = size(get_inputs(io_pairs), 2) - n_train
     else
-        n_train = Int( size(get_inputs(io_pairs), 2))
+        n_train = Int(size(get_inputs(io_pairs), 2))
         n_test = n_train
     end
 

--- a/test/Methods/runtests.jl
+++ b/test/Methods/runtests.jl
@@ -54,7 +54,7 @@ tol = 1e3 * eps()
         ) #don't invert, just make PD 
         reg_new = get_regularization(rfm_warn2)
         @test isposdef(reg_new)
-        @test minimum(eigvals(reg_new)) > 1e12 * eps()
+        @test minimum(eigvals(reg_new)) > (1e12-1) * eps() 
 
         rfm = RandomFeatureMethod(
             sff,

--- a/test/Methods/runtests.jl
+++ b/test/Methods/runtests.jl
@@ -54,7 +54,7 @@ tol = 1e3 * eps()
         ) #don't invert, just make PD 
         reg_new = get_regularization(rfm_warn2)
         @test isposdef(reg_new)
-        @test minimum(eigvals(reg_new)) > (1e12-1) * eps() 
+        @test minimum(eigvals(reg_new)) > (1e12 - 1) * eps()
 
         rfm = RandomFeatureMethod(
             sff,


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Content
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->

- adds comparisons for cross-validation and non-cross validation loss functions to the nd_to_1d loss functions
- updates other loss functions in 1d too (no noticeable effect to result here)
- also adds bugfix to MacOS CI by removing `arch` specification and moving tests from `1.6` to `lts` 




<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
